### PR TITLE
Add /etc handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@
 #
 AUTOMAKE_OPTIONS = 1.6 foreign check-news dist-bzip2
 #
-SUBDIRS = sbin man systemd logrotate doc etc
+SUBDIRS = sbin man systemd logrotate dracut doc etc
 
 CLEANFILES = *~
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,22 +16,26 @@ then
     ISSUEDIR=${prefix}/lib/issue.d
     UDEVRULESDIR=${prefix}/lib/udev/rules.d
     SYSTEMDDIR=${prefix}/lib/systemd/system
+    DRACUTDIR=${prefix}/lib/dracut/modules.d
   else
     TMPFILESDIR=${exec_prefix}/lib/tmpfiles.d
     ISSUEDIR=${exec_prefix}/lib/issue.d
     UDEVRULESDIR=${exec_prefix}/lib/udev/rules.d
     SYSTEMDDIR=${exec_prefix}/lib/systemd/system
+    DRACUTDIR=${exec_prefix}/lib/dracut/modules.d
   fi
 else
   TMPFILESDIR=${libexecdir}/tmpfiles.d
   ISSUEDIR=${libexecdir}/issue.d
   UDEVRULESDIR=${libexecdir}/udev/rules.d
   SYSTEMDDIR=${libexecdir}/systemd/system
+  DRACUTDIR=${libexecdir}/dracut/modules.d
 fi
 AC_SUBST(TMPFILESDIR)
 AC_SUBST(ISSUEDIR)
 AC_SUBST(UDEVRULESDIR)
 AC_SUBST(SYSTEMDDIR)
+AC_SUBST(DRACUTDIR)
 LOGROTATEDDIR=${sysconfdir}/logrotate.d
 AC_SUBST(LOGROTATEDDIR)
 
@@ -73,5 +77,5 @@ else
 fi
 
 AC_OUTPUT([Makefile sbin/Makefile man/Makefile systemd/Makefile \
-	logrotate/Makefile doc/Makefile etc/Makefile \
+	logrotate/Makefile dracut/Makefile doc/Makefile etc/Makefile \
 	sbin/transactional-update])

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Ignaz Forster <iforster@suse.com>
+# Copyright (c) 2018 Ignaz Forster <iforster@suse.de>
 #
 
 modulesdir = @DRACUTDIR@/50transactional-update

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -4,6 +4,6 @@
 
 modulesdir = @DRACUTDIR@/50transactional-update
 
-modules_SCRIPTS = transactional-update-etc-cleaner.sh module-setup.sh
+modules_SCRIPTS = transactional-update-etc-cleaner.sh transactional-update-etc-cleaner.service module-setup.sh
 
 EXTRA_DIST = $(SCRIPTS)

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2018 Ignaz Forster <iforster@suse.com>
+#
+
+modulesdir = @DRACUTDIR@/50transactional-update
+
+modules_SCRIPTS = transactional-update-etc-cleaner.sh module-setup.sh
+
+EXTRA_DIST = $(SCRIPTS)

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -13,4 +13,5 @@ depends() {
 # called by dracut
 install() {
     inst_hook pre-pivot 10 "$moddir/transactional-update-etc-cleaner.sh"
+    inst_multiple cmp rmdir
 }

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    test -f /etc/fstab.sys || [[ -n $add_fstab  ||  -n $fstab_lines ]]
+}
+
+# called by dracut
+depends() {
+    echo fstab-sys
+}
+
+# called by dracut
+install() {
+    inst_hook pre-pivot 10 "$moddir/transactional-update-etc-cleaner.sh"
+}

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -12,6 +12,9 @@ depends() {
 
 # called by dracut
 install() {
-    inst_hook pre-pivot 10 "$moddir/transactional-update-etc-cleaner.sh"
+    inst_script "$moddir/transactional-update-etc-cleaner.sh" /bin/transactional-update-etc-cleaner
+    inst_simple "$moddir/transactional-update-etc-cleaner.service" $systemdsystemunitdir/transactional-update-etc-cleaner.service
+    mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
+    ln_r "$systemdsystemunitdir/transactional-update-etc-cleaner.service" "$systemdsystemunitdir/initrd.target.wants/transactional-update-etc-cleaner.service"
     inst_multiple cmp rmdir
 }

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -16,5 +16,6 @@ install() {
     inst_simple "$moddir/transactional-update-etc-cleaner.service" $systemdsystemunitdir/transactional-update-etc-cleaner.service
     mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
     ln_r "$systemdsystemunitdir/transactional-update-etc-cleaner.service" "$systemdsystemunitdir/initrd.target.wants/transactional-update-etc-cleaner.service"
-    inst_multiple cmp rmdir
+    inst_multiple stat rmdir
+    inst_multiple -o getfattr
 }

--- a/dracut/transactional-update-etc-cleaner.service
+++ b/dracut/transactional-update-etc-cleaner.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=transactional-update /etc overlay cleaner
+Requires=dracut-pre-pivot.service
+After=dracut-pre-pivot.service
+Before=initrd-cleanup.service
+DefaultDependencies=no
+ConditionPathExists=/sysroot/var/lib/overlay/etc/transactional-update.newsnapshot
+
+[Service]
+Type=oneshot
+Environment=DRACUT_SYSTEMD=1
+Environment=NEWROOT=/sysroot
+StandardInput=null
+StandardOutput=syslog
+StandardError=syslog+console
+ExecStart=/bin/transactional-update-etc-cleaner

--- a/dracut/transactional-update-etc-cleaner.sh
+++ b/dracut/transactional-update-etc-cleaner.sh
@@ -1,6 +1,22 @@
 #!/bin/bash -e
-
+#
 # Purge contents of etc overlay on first boot after creating new snapshot
+#
+# Author: Ignaz Forster <iforster@suse.de>
+# Copyright (C) 2018 SUSE Linux GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ETC_OVERLAY="${NEWROOT}/var/lib/overlay/etc"
 TU_FLAGFILE="${ETC_OVERLAY}/transactional-update.newsnapshot"

--- a/dracut/transactional-update-etc-cleaner.sh
+++ b/dracut/transactional-update-etc-cleaner.sh
@@ -1,55 +1,91 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Purge contents of etc overlay on first boot after creating new snapshot
 
 ETC_OVERLAY="${NEWROOT}/var/lib/overlay/etc"
-TA_FLAGFILE="${ETC_OVERLAY}/transactional-update.newsnapshot"
+TU_FLAGFILE="${ETC_OVERLAY}/transactional-update.newsnapshot"
 
 # Remove files from overlay with safety checks
-# 
-purge_overlay() {
-  local dir="$1"
+# etc directory mustn't be deleted completely, as it's still mounted and the kernel won't be able to recover from that (different inode?)
+clean_overlay() {
+  local dir="${1:-.}"
   local file
+  local snapdir="${NEWROOT}/${PREV_SNAPSHOT_DIR}/etc/${dir}"
 
-  cd "${ETC_OVERLAY}/${dir}"
+  pushd "${ETC_OVERLAY}/${dir}" >/dev/null
   for file in .[^.]* ..?* *; do
+    # Filter unexpanded globs of "for" loop
+    if [ ! -e "${file}" ]; then
+      continue
+    fi
+
     # Recursively process directories
     if [ -d "${file}" ]; then
-      purge_overlay "${dir}/${file}"
-      rmdir --ignore-fail-on-non-empty "${file}"
-    # Overlayfs creates a character device for removed files
-    elif [ -c "${file}" ]; then
-      echo "transactional-update: ${dir}/${file} was deleted after snapshot creation."
-    # Verify that files in the overlay haven't changed since taking the snapshot
-    elif cmp --quiet "${file}" "${NEWROOT}/${PREV_SNAPSHOT_DIR}/etc/${dir}/${file}"; then
+      clean_overlay "${dir}/${file}"
+      rmdir --ignore-fail-on-non-empty -- "${file}"
+    # Overlayfs creates a character device for removed files / directories
+    elif [ -c "${file}" -a ! -e "${snapdir}/${file}" ]; then
       echo "transactional-update: Deleting ${dir}/${file}..."
-      rm "${file}"
+      rm -- "${file}"
+    # Verify that files in the overlay haven't changed since taking the snapshot
+    elif cmp --quiet -- "${file}" "${snapdir}/${file}"; then
+      echo "transactional-update: Deleting ${dir}/${file}..."
+      rm -- "${file}"
     # File seems to have been modified, warn user
     else
-      if [ -e "${file}" ]; then  # Filter unexpanded globs of "for" loop
-        echo "transactional-update: ${dir}/${file} was modified after snapshot creation."
-      fi
+      echo "transactional-update: ${dir}/${file} was modified after snapshot creation."
     fi
   done
-  cd ..
+  popd >/dev/null
 }
 
-if [ -e "${ETC_OVERLAY}" -a -e "${TA_FLAGFILE}" ]; then
-  CURRENT_SNAPSHOT_ID="`btrfs subvolume get-default /${NEWROOT} | sed 's#.*/.snapshots/\(.*\)/snapshot#\1#g'`"
-  mount -t btrfs -o ro,subvol=@/.snapshots ${root#block:*} ${NEWROOT}/.snapshots
-  # TODO: Fehlerbehandlung
-  PREV_SNAPSHOT_ID="`sed -n 's#.*<pre_num>\([^>]*\)</pre_num>#\1#p' ${NEWROOT}/.snapshots/${CURRENT_SNAPSHOT_ID}/info.xml`"
-  PREV_SNAPSHOT_DIR="`btrfs subvolume list /${NEWROOT} | sed -n 's#.*\(/.snapshots/'${PREV_SNAPSHOT_ID}'/snapshot\)#\1#p'`"
-  if [ -n "${PREV_SNAPSHOT_DIR}" ]; then
-    mount -t btrfs -o ro,subvol=@${PREV_SNAPSHOT_DIR} ${root#block:*} "${NEWROOT}/${PREV_SNAPSHOT_DIR}"
-    rm "${TA_FLAGFILE}"
-    cd "${ETC_OVERLAY}"
-    purge_overlay .
-    mount -o remount "${NEWROOT}/etc"
-  else
-    echo "transactional-update: Previous snapshot ${PREV_SNAPSHOT_ID} not available any more - continuing..."
-  fi
-fi
+# Delete all contents of the overlay
+remove_overlay() {
+  echo "transactional-update: Previous snapshot ${PREV_SNAPSHOT_ID} not available; deleting all overlay contents."
+  cd "${ETC_OVERLAY}"
+  rm -rf -- .[^.]* ..?* *
+}
 
-umount "${NEWROOT}/${PREV_SNAPSHOT_DIR}"
-umount "${NEWROOT}/.snapshots"
+# Mount directories necessary for file comparison
+# Note: Will not break execution if snapshot is not available
+prepare_environment() {
+  if ! findmnt "${NEWROOT}/.snapshots" >/dev/null; then
+    if ! mount -t btrfs -o ro,subvol=@/.snapshots ${root#block:*} ${NEWROOT}/.snapshots; then
+      echo "transactional-update: Could not mount .snapshots!"
+      return 1
+    fi
+    UMOUNT_DOT_SNAPSHOTS=1
+  fi
+  CURRENT_SNAPSHOT_ID="`btrfs subvolume get-default /${NEWROOT} | sed 's#.*/.snapshots/\(.*\)/snapshot#\1#g'`"
+  PREV_SNAPSHOT_ID="`sed -n 's#.*<pre_num>\([^>]\+\)</pre_num>#\1#p' ${NEWROOT}/.snapshots/${CURRENT_SNAPSHOT_ID}/info.xml`"
+  PREV_SNAPSHOT_DIR="`btrfs subvolume list /${NEWROOT} | sed -n 's#.*\(/.snapshots/'${PREV_SNAPSHOT_ID}'/snapshot\)#\1#p'`"
+  if [ -n "${PREV_SNAPSHOT_DIR}" ] && ! findmnt "${NEWROOT}/${PREV_SNAPSHOT_DIR}" >/dev/null; then
+    if ! mount -t btrfs -o ro,subvol=@${PREV_SNAPSHOT_DIR} ${root#block:*} "${NEWROOT}/${PREV_SNAPSHOT_DIR}"; then
+      echo "transactional-update: Warning: Could not mount old snapshot directory ${PREV_SNAPSHOT_DIR}!"
+      return 1
+    fi
+    UMOUNT_PREV_SNAPSHOT=1
+  fi
+  return 0
+}
+
+release_environment() {
+  if [ -n "${UMOUNT_PREV_SNAPSHOT}" ]; then
+    umount "${NEWROOT}/${PREV_SNAPSHOT_DIR}"
+  fi
+  if [ -n "${UMOUNT_DOT_SNAPSHOTS}" ]; then
+    umount "${NEWROOT}/.snapshots"
+  fi
+}
+
+if [ -e "${ETC_OVERLAY}" -a -e "${TU_FLAGFILE}" ]; then
+  # Previous snapshot may not be available; just delete all overlay contents in this case
+  rm "${TU_FLAGFILE}"
+  if prepare_environment; then
+    clean_overlay
+  else
+    remove_overlay
+  fi
+  mount -o remount "${NEWROOT}/etc"
+  release_environment
+fi

--- a/dracut/transactional-update-etc-cleaner.sh
+++ b/dracut/transactional-update-etc-cleaner.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Purge contents of etc overlay on first boot after a new snapshot
+
+etc_overlay="/sysroot/var/lib/overlay/etc"
+ta_flagfile="${etc_overlay}/transactional-update.newsnapshot"
+
+if [ -e "${etc_overlay}" -a -e "${ta_flagfile}" ]; then
+  rm "${ta_flagfile}"
+  rm -rf "${etc_overlay}"/.[^.]* "${etc_overlay}"/..?* "${etc_overlay}"/*
+  mount -o remount "/sysroot/etc"
+fi

--- a/dracut/transactional-update-etc-cleaner.sh
+++ b/dracut/transactional-update-etc-cleaner.sh
@@ -1,12 +1,55 @@
-#!/bin/sh
+#!/bin/bash
 
-# Purge contents of etc overlay on first boot after a new snapshot
+# Purge contents of etc overlay on first boot after creating new snapshot
 
-etc_overlay="/sysroot/var/lib/overlay/etc"
-ta_flagfile="${etc_overlay}/transactional-update.newsnapshot"
+ETC_OVERLAY="${NEWROOT}/var/lib/overlay/etc"
+TA_FLAGFILE="${ETC_OVERLAY}/transactional-update.newsnapshot"
 
-if [ -e "${etc_overlay}" -a -e "${ta_flagfile}" ]; then
-  rm "${ta_flagfile}"
-  rm -rf "${etc_overlay}"/.[^.]* "${etc_overlay}"/..?* "${etc_overlay}"/*
-  mount -o remount "/sysroot/etc"
+# Remove files from overlay with safety checks
+# 
+purge_overlay() {
+  local dir="$1"
+  local file
+
+  cd "${ETC_OVERLAY}/${dir}"
+  for file in .[^.]* ..?* *; do
+    # Recursively process directories
+    if [ -d "${file}" ]; then
+      purge_overlay "${dir}/${file}"
+      rmdir --ignore-fail-on-non-empty "${file}"
+    # Overlayfs creates a character device for removed files
+    elif [ -c "${file}" ]; then
+      echo "transactional-update: ${dir}/${file} was deleted after snapshot creation."
+    # Verify that files in the overlay haven't changed since taking the snapshot
+    elif cmp --quiet "${file}" "${NEWROOT}/${PREV_SNAPSHOT_DIR}/etc/${dir}/${file}"; then
+      echo "transactional-update: Deleting ${dir}/${file}..."
+      rm "${file}"
+    # File seems to have been modified, warn user
+    else
+      if [ -e "${file}" ]; then  # Filter unexpanded globs of "for" loop
+        echo "transactional-update: ${dir}/${file} was modified after snapshot creation."
+      fi
+    fi
+  done
+  cd ..
+}
+
+if [ -e "${ETC_OVERLAY}" -a -e "${TA_FLAGFILE}" ]; then
+  CURRENT_SNAPSHOT_ID="`btrfs subvolume get-default /${NEWROOT} | sed 's#.*/.snapshots/\(.*\)/snapshot#\1#g'`"
+  mount -t btrfs -o ro,subvol=@/.snapshots ${root#block:*} ${NEWROOT}/.snapshots
+  # TODO: Fehlerbehandlung
+  PREV_SNAPSHOT_ID="`sed -n 's#.*<pre_num>\([^>]*\)</pre_num>#\1#p' ${NEWROOT}/.snapshots/${CURRENT_SNAPSHOT_ID}/info.xml`"
+  PREV_SNAPSHOT_DIR="`btrfs subvolume list /${NEWROOT} | sed -n 's#.*\(/.snapshots/'${PREV_SNAPSHOT_ID}'/snapshot\)#\1#p'`"
+  if [ -n "${PREV_SNAPSHOT_DIR}" ]; then
+    mount -t btrfs -o ro,subvol=@${PREV_SNAPSHOT_DIR} ${root#block:*} "${NEWROOT}/${PREV_SNAPSHOT_DIR}"
+    rm "${TA_FLAGFILE}"
+    cd "${ETC_OVERLAY}"
+    purge_overlay .
+    mount -o remount "${NEWROOT}/etc"
+  else
+    echo "transactional-update: Previous snapshot ${PREV_SNAPSHOT_ID} not available any more - continuing..."
+  fi
 fi
+
+umount "${NEWROOT}/${PREV_SNAPSHOT_DIR}"
+umount "${NEWROOT}/.snapshots"

--- a/sbin/transactional-update-helper.cpp
+++ b/sbin/transactional-update-helper.cpp
@@ -1,5 +1,6 @@
 /* transactional-update-helper - native helper scripts for transactional-update
 
+   Author: Ignaz Forster <iforster@suse.de>
    Copyright (C) 2018 SUSE Linux GmbH
 
    This program is free software: you can redistribute it and/or modify

--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -605,7 +605,7 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 
     # Copy the contents of /etc into the backup snapshot
     log_info "Copying /etc state into backup snapshot"
-    rsync --archive --quiet --exclude "${NEW_SNAPSHOT_FLAG}" --delete-excluded /etc ${BACKUP_SNAPSHOT_DIR}
+    rsync --archive --xattrs --acls --quiet --exclude "${NEW_SNAPSHOT_FLAG}" --delete-excluded /etc ${BACKUP_SNAPSHOT_DIR}
     if [ $? -ne 0 ]; then
 	log_error "ERROR: copying of /etc into backup snapshot failed!"
 	quit 1;
@@ -701,7 +701,7 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 
     # Copy the contents of /etc
     log_info "Copying /etc state into snapshot"
-    rsync --archive --quiet --exclude "${NEW_SNAPSHOT_FLAG}" --delete-excluded /etc ${SNAPSHOT_DIR}
+    rsync --archive --xattrs --acls --quiet --exclude "${NEW_SNAPSHOT_FLAG}" --delete-excluded /etc ${SNAPSHOT_DIR}
     if [ $? -ne 0 ]; then
 	log_error "ERROR: copying of /etc into snapshot failed!"
 	quit 1;

--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -50,10 +50,6 @@ HAS_SEPARATE_VAR=0
 SNAPSHOT_ID=""
 SECOND_SNAPSHOT_ID=""
 SNAPPER_NO_DBUS=""
-KDUMP_SYSCONFIG="/etc/sysconfig/kdump"
-# Config files which the user could have modified and which should
-# be copied to the snapshot.
-CONFIG_FILES_TO_COPY="/etc/default/grub"
 
 # Load config
 if [ -r ${SYSTEMCONFFILE} ]; then
@@ -152,39 +148,7 @@ rebuild_kdump_initrd() {
     test -f /usr/lib/systemd/system/kdump.service || return
     systemctl is-enabled --quiet kdump.service
     if [ $? = 0 -a -x ${MOUNT_DIR}/usr/sbin/tu-rebuild-kdump-initrd ]; then
-	if [ ${KDUMP_SYSCONFIG} -nt ${MOUNT_DIR}/${KDUMP_SYSCONFIG} ]; then
-	    cp -a ${KDUMP_SYSCONFIG} ${MOUNT_DIR}/${KDUMP_SYSCONFIG}
-	fi
 	chroot ${MOUNT_DIR} /usr/sbin/tu-rebuild-kdump-initrd |& tee -a ${LOGFILE}
-    fi
-}
-
-# If the SHA256 sum of passwd, group or shadow has changed then copy the files
-# to /usr/etc. If libnss_usrfiles is installed those files will be taken into
-# account as a secondary source if an entry is not found in /etc.
-calc_user_group_sha256sum () {
-    SHA256_passwd=`sha256sum ${MOUNT_DIR}/etc/passwd | awk '{ print $1 }'`
-    SHA256_group=`sha256sum ${MOUNT_DIR}/etc/group | awk '{ print $1 }'`
-    SHA256_shadow=`sha256sum ${MOUNT_DIR}/etc/shadow | awk '{ print $1 }'`
-}
-
-copy_user_group_accounts () {
-    # Only copy files to usr/etc if libnss_usrfiles is installed.
-    test -d ${MOUNT_DIR}/usr/etc || return
-
-    NEWSUM=`sha256sum ${MOUNT_DIR}/etc/passwd | awk '{ print $1 }'`
-    if [ ${NEWSUM} != ${SHA256_passwd} ]; then
-	cp -a ${MOUNT_DIR}/etc/passwd ${MOUNT_DIR}/usr/etc/
-    fi
-
-    NEWSUM=`sha256sum ${MOUNT_DIR}/etc/group | awk '{ print $1 }'`
-    if [ ${NEWSUM} != ${SHA256_group} ]; then
-	cp -a ${MOUNT_DIR}/etc/group ${MOUNT_DIR}/usr/etc/
-    fi
-
-    NEWSUM=`sha256sum ${MOUNT_DIR}/etc/shadow | awk '{ print $1 }'`
-    if [ ${NEWSUM} != ${SHA256_shadow} ]; then
-	cp -a ${MOUNT_DIR}/etc/shadow ${MOUNT_DIR}/usr/etc/
     fi
 }
 
@@ -675,11 +639,7 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
         rm -f ${SNAPSHOT_DIR}/var/update_snapshot.test
     fi
 
-    # On a read only system, make sure that /etc/zypp in the
-    # snapshot is current, could come from a overlayfs which
-    # means not part of the snapshot itself
     if [ ${RO_ROOT} == "true" ]; then
-	DIR_TO_MOUNT="${DIR_TO_MOUNT} etc/zypp"
 	if [ ${RUN_SHELL} -eq 1 ]; then
 	    DIR_TO_MOUNT="${DIR_TO_MOUNT} root"
 	fi
@@ -760,16 +720,7 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
     # transactional update
     export TRANSACTIONAL_UPDATE=true
 
-    # Copy modified config files to the snapshot
-    for CF in ${CONFIG_FILES_TO_COPY} ; do
-	if [ ${CF} -nt ${MOUNT_DIR}/${CF} ]; then
-	    cp -a ${CF} ${MOUNT_DIR}/${CF}
-	fi
-    done
-
     if [ -n "${ZYPPER_ARG}" ]; then
-
-	calc_user_group_sha256sum
 
 	log_info "Calling zypper ${ZYPPER_ARG}"
 	if [ -n "${ZYPPER_NONINTERACTIVE}" ]; then
@@ -794,7 +745,6 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 	fi
 
 	if [ $RETVAL -eq 0 -o $RETVAL -eq 102 -o $RETVAL -eq 103 -o \( $DO_DUP -eq 0 -a $RETVAL -eq 106 \) ]; then
-	    copy_user_group_accounts
 	    REBUILD_KDUMP_INITRD=1
 	    # check if products are updated and we need to re-register
 	    # at next boot.

--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -722,6 +722,14 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 	fi
     done
 
+    # Copy the contents of /etc
+    log_info "Copying /etc state into snapshot"
+    rsync --archive --quiet --exclude '/etc/transactional-update.newsnapshot' --delete-excluded /etc ${SNAPSHOT_DIR}
+    if [ $? -ne 0 ]; then
+	log_error "ERROR: copying of /etc into snapshot failed!"
+	quit 1;
+    fi
+
     # If we have a seperate /var, create some directories which we
     # will delete again later.
     if [ ${HAS_SEPARATE_VAR} -eq 1 ]; then
@@ -893,6 +901,8 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 		# Save the old snapshot or else it will get lost.
 		add_unique_id ${CURRENT_SNAPSHOT_ID}
 		save_state_file ${SNAPSHOT_ID}
+		# Mark /etc contents as deleteable
+		touch /etc/transactional-update.newsnapshot
 		# Reset in-progress flag
 		snapper ${SNAPPER_NO_DBUS} modify -u "transactional-update-in-progress=" ${SNAPSHOT_ID}
 	    fi

--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -43,12 +43,13 @@ CONFFILE="@sysconfdir@/transactional-update.conf"
 SYSTEMCONFFILE="@prefix@@sysconfdir@/transactional-update.conf"
 LOGFILE="/var/log/transactional-update.log"
 STATE_FILE="/var/lib/misc/transactional-update.state"
+NEW_SNAPSHOT_FLAG="/var/lib/overlay/etc/transactional-update.newsnapshot"
 SELF_PATH="`dirname $0`"
 PACKAGE_UPDATES=0
 ZYPPER_AUTO_IMPORT_KEYS=0
 HAS_SEPARATE_VAR=0
 SNAPSHOT_ID=""
-SECOND_SNAPSHOT_ID=""
+BACKUP_SNAPSHOT_ID=""
 SNAPPER_NO_DBUS=""
 
 # Load config
@@ -158,9 +159,9 @@ quit() {
 	log_error "Removing snapshot #${SNAPSHOT_ID}..."
 	snapper ${SNAPPER_NO_DBUS} delete ${SNAPSHOT_ID} |& tee -a ${LOGFILE}
     fi
-    if [ -n "${SECOND_SNAPSHOT_ID}" ] ; then
-	log_error "Removing snapshot #${SECOND_SNAPSHOT_ID}..."
-	snapper ${SNAPPER_NO_DBUS} delete ${SECOND_SNAPSHOT_ID} |& tee -a ${LOGFILE}
+    if [ -n "${BACKUP_SNAPSHOT_ID}" ] ; then
+	log_error "Removing snapshot #${BACKUP_SNAPSHOT_ID}..."
+	snapper ${SNAPPER_NO_DBUS} delete ${BACKUP_SNAPSHOT_ID} |& tee -a ${LOGFILE}
     fi
     if [ $USE_SALT_GRAINS -eq 1 ]; then
 	if [ -f /etc/salt/grains ]; then
@@ -580,25 +581,41 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 	fi
     fi
 
-    # If the current root file system is not read-only, a read-only copy for rollback has to be created first.
+    # Create a backup snapshot of the current system state (i.e. preserve the /etc overlay contents on a read-only
+    # system or the general system state on a read-write file system, similar to what zypper / snapper does).
     # Hint: The rw subvolume is not shown in grub2.
-    if [ ${RO_ROOT} == "false" ]; then
-	log_info "Creating read-only snapshot of current read-write root filesystem (#${CURRENT_SNAPSHOT_ID})"
-	SECOND_SNAPSHOT_ID=`snapper create -p -c number -u "important=yes" -d "RO-Clone of #${CURRENT_SNAPSHOT_ID}"`
+    log_info "Creating read-only snapshot of current system state (#${CURRENT_SNAPSHOT_ID})"
+    BACKUP_SNAPSHOT_ID=`snapper create -p -t pre -c number -u "important=yes" -d "RO-Clone of #${CURRENT_SNAPSHOT_ID}"`
+    BACKUP_SNAPSHOT_DIR=/.snapshots/${BACKUP_SNAPSHOT_ID}/snapshot
+    if [ $? -ne 0 ]; then
+	SNAPPER_NO_DBUS="--no-dbus"
+	BACKUP_SNAPSHOT_ID=`snapper --no-dbus create -p -t pre -c number -u "important=yes" -d "RO-Clone of #${CURRENT_SNAPSHOT_ID}"`
 	if [ $? -ne 0 ]; then
-	    SNAPPER_NO_DBUS="--no-dbus"
-	    SECOND_SNAPSHOT_ID=`snapper --no-dbus create -p -c number -u "important=yes" -d "RO-Clone of #${CURRENT_SNAPSHOT_ID}"`
-	    if [ $? -ne 0 ]; then
-		log_error "ERROR: snapper create failed!"
-		exit 1
-	    fi
+	    log_error "ERROR: snapper create failed!"
+	    exit 1
 	fi
     fi
 
-    SNAPSHOT_ID=`snapper create -p -u "transactional-update-in-progress=yes" -d "Snapshot Update"`
+    # Make the backup snapshot read-write:
+    btrfs property set ${BACKUP_SNAPSHOT_DIR} ro false
+    if [ $? -ne 0 ]; then
+	log_error "ERROR: changing ${BACKUP_SNAPSHOT_DIR} to read-write failed!"
+	quit 1;
+    fi
+
+    # Copy the contents of /etc into the backup snapshot
+    log_info "Copying /etc state into backup snapshot"
+    rsync --archive --quiet --exclude "${NEW_SNAPSHOT_FLAG}" --delete-excluded /etc ${BACKUP_SNAPSHOT_DIR}
+    if [ $? -ne 0 ]; then
+	log_error "ERROR: copying of /etc into backup snapshot failed!"
+	quit 1;
+    fi
+
+    # Create the working snapshot
+    SNAPSHOT_ID=`snapper create --type post --pre-number ${BACKUP_SNAPSHOT_ID} -p -u "transactional-update-in-progress=yes" -d "Snapshot Update"`
     if [ $? -ne 0 ]; then
 	SNAPPER_NO_DBUS="--no-dbus"
-	SNAPSHOT_ID=`snapper --no-dbus create -p -u "transactional-update-in-progress=yes" -d "Snapshot Update"`
+	SNAPSHOT_ID=`snapper --no-dbus create --type post --pre-number ${BACKUP_SNAPSHOT_ID} -p -u "transactional-update-in-progress=yes" -d "Snapshot Update"`
 	if [ $? -ne 0 ]; then
 	    log_error "ERROR: snapper create failed!"
 	    quit 1
@@ -684,7 +701,7 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 
     # Copy the contents of /etc
     log_info "Copying /etc state into snapshot"
-    rsync --archive --quiet --exclude '/etc/transactional-update.newsnapshot' --delete-excluded /etc ${SNAPSHOT_DIR}
+    rsync --archive --quiet --exclude "${NEW_SNAPSHOT_FLAG}" --delete-excluded /etc ${SNAPSHOT_DIR}
     if [ $? -ne 0 ]; then
 	log_error "ERROR: copying of /etc into snapshot failed!"
 	quit 1;
@@ -851,8 +868,8 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 		# Save the old snapshot or else it will get lost.
 		add_unique_id ${CURRENT_SNAPSHOT_ID}
 		save_state_file ${SNAPSHOT_ID}
-		# Mark /etc contents as deleteable
-		touch /etc/transactional-update.newsnapshot
+		# Create flag file for overlay purging
+		touch "${NEW_SNAPSHOT_FLAG}"
 		# Reset in-progress flag
 		snapper ${SNAPPER_NO_DBUS} modify -u "transactional-update-in-progress=" ${SNAPSHOT_ID}
 	    fi
@@ -864,6 +881,13 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
     if [ $? -ne 0 ]; then
 	log_error "ERROR: changing ${SNAPSHOT_DIR} to ro=${RO_ROOT} failed!"
 	EXITCODE=1
+    fi
+    if [ -n ${BACKUP_SNAPSHOT_DIR} ]; then
+	btrfs property set ${BACKUP_SNAPSHOT_DIR} ro ${RO_ROOT}
+	if [ $? -ne 0 ]; then
+	    log_error "ERROR: changing ${BACKUP_SNAPSHOT_DIR} to ro=${RO_ROOT} failed!"
+	    EXITCODE=1
+	fi
     fi
 
     if [ ${EXITCODE} -ne 0 ]; then


### PR DESCRIPTION
### Current situation

With a read-only file system the /etc directory is mounted as an overlay file system, consisting of
- /etc (lower layer)
- /var/lib/overlay/etc upper (writeable) layer.

During an update with transactional-update only the **lower** layer is visible; RPM packages modifying /etc will never see the production directory, but only modify the default files. As a consequence also common patterns like _fillup-templates_ or _update-alternatives_ won't work as expected if any file has been modified previously.

### Concept
The contents of /etc have to be visible during the update the packages. 
Configuration files visible to the currently running system must not be modified.
Files modified after snapshot generation should still be visible in the new snapshot after a reboot.

### Solution
This approach followed by this branch will copy the current state of /etc into the new snapshot before updating the packages.
One additional snapshot will be created to enable a rollback to the current state (similar to the default zypper behaviour); this snapshot is identical to the previous ro snapshot, only /etc contents will be changed.

On reboot the contents of the /etc overlay will be purged (exception: files that have been changed between snapshot generation and reboot; for those files a warning will be printed). This step takes place in the initrd to ensure the actual system will see the final /etc state.

### Caveats
- Files in the /etc overlay (i.e. not persisted into a snapshot yet) will be visible to all snapshots (this may be intended, though).
- Old snapshots before this merge should not be booted any more: Due to the fact that the /etc overlay will be purged, those snapshots would get an /etc directory with mostly default entries instead of the actual configuration.

### Alternatives
* Overlay stacking: Would have provided the best isolation between snapshots and automatic conflict resolution, but requires complex logic in initrd to avoid limitless increase of layers.
* /etc snapshots: No direct mechanism to apply changes after snapshot creation to the next boot; would require different partitioning scheme.

In comparison to those alternatives the current "copy" solution seems to be the best option, so using this branch for the pull request.