### PR TITLE
Warn user when default snapshot isn't current snapshot

### DIFF
--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -573,7 +573,7 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
     # If the current snapshot and the default snapshot differ,
     # there has been changes that we are now discarding.
     # At least warn the user of this
-    if [ "${DEFAULT_SNAPSHOT_ID}" -ne "${CURRENT_SNAPSHOT_ID} ]; then
+    if [ "${DEFAULT_SNAPSHOT_ID}" -ne "${CURRENT_SNAPSHOT_ID}" ]; then
        log_error: "WARNING: Default snapshot differs from current snapshot"
        log_error: "WARNING: Any changes made to the system will be discarded"
     fi


### PR DESCRIPTION
If the user isn't aware, they might end up with surprising dataloss, this at least gives them a sporting chance