### PR TITLE
Use exec to optimize away fork during process substition

### DIFF
--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -83,7 +83,7 @@ if [ ! -e /proc/$$/fd/4 ]; then
 	exec 4>&2
 fi
 # Log stderr to log file
-exec 2> >(tee -a "${LOGFILE}")
+exec 2> >(exec tee -a "${LOGFILE}")
 
 self_update() {
     if [ ${DO_SELF_UPDATE} == 0 ]; then


### PR DESCRIPTION
I wonder why bash doesn't optimize this case itself, but this definitely works
to avoid boo#1111897.