### PR TITLE
Restore compatibility with RPM < 4.15

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,8 @@ AC_PROG_LN_S
 dnl
 dnl Check for librpm
 dnl
-PKG_CHECK_MODULES([LIBRPM], [rpm])
+PKG_CHECK_MODULES([LIBRPM], [rpm >= 4.15], AC_DEFINE([HAVE_RPMDBCOOKIE]),
+	[PKG_CHECK_MODULES([LIBRPM], [rpm])])
 
 AC_ARG_WITH([doc],
 	[AS_HELP_STRING([--with-doc], [Build documentation])], ,

--- a/sbin/create_dirs_from_rpmdb.c
+++ b/sbin/create_dirs_from_rpmdb.c
@@ -388,10 +388,12 @@ main (int argc, char *argv[])
   ts = rpmtsCreate ();
   rpmtsSetRootDir (ts, rpmcliRootDir);
 
+#ifdef HAVE_RPMDBCOOKIE
   rpmtsOpenDB (ts, O_RDONLY);
   rpmdbOpenAll (rpmtsGetRdb (ts));
   rpmdb_cookie = rpmdbCookie (rpmtsGetRdb (ts));
   rpmtsCloseDB (ts);
+#endif
   if (rpmdb_cookie && rpmCookieUnchanged(rpmdb_cookie))
     {
       if (verbose_flag)


### PR DESCRIPTION
When optimizing create_dirs_from_rpmdb a dependency against a new RPM version
was introduced by using rpmdbCookie(). This function is not defined in older
librpm versions.
To restore compatibility with older version detect the librpm version and
just skip the optimization in that case.