### PR TITLE
Move /.autorelabel to /etc/selinux

### DIFF
--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -1361,6 +1361,9 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 	sed -i -e 's|^SELINUX=.*|SELINUX=enforcing|g' \
 	    -e 's|^SELINUXTYPE=.*|SELINUXTYPE=targeted|g' \
 	    "${MOUNT_DIR}/etc/selinux/config"
+
+	# Move an /.autorelabel file from initial installation to writeable location
+	test -f ${MOUNT_DIR}/.autorelabel && mv ${MOUNT_DIR}/.autorelabel ${MOUNT_DIR}/etc/selinux/.autorelabel
     fi
 
     if [ ${REWRITE_INITRD} -eq 1 ]; then


### PR DESCRIPTION
selinux-policy-<variant> will create /.autorelabel during an initial
installation, as we cannot detect if we will run on an transactional system.
Cleanup afterwards, else we will never be able to delete the file.