### PR TITLE
Fix call to open() for creating the transaction lock file to set mode

### DIFF
--- a/tukit/tukit.cpp
+++ b/tukit/tukit.cpp
@@ -145,7 +145,7 @@ int TUKit::processCommand(char *argv[]) {
 class Lock {
 public:
     Lock(){
-        lockfile = open(config.get("LOCKFILE").c_str(), O_CREAT|O_WRONLY);
+        lockfile = open(config.get("LOCKFILE").c_str(), O_CREAT|O_WRONLY, 0600);
         if (lockfile < 0) {
             throw runtime_error{"Could not create lock file '" + config.get("LOCKFILE") + "': " + strerror(errno)};
         }


### PR DESCRIPTION
When using `open()` with `O_CREAT`, it is required to set a mode in which
the file is created. Otherwise, `open()` fails with the following error:

```
In file included from /usr/include/fcntl.h:329,
                 from tukit.cpp:12:
In function 'open',
    inlined from 'Lock::Lock()' at tukit.cpp:148:24:
/usr/include/bits/fcntl2.h:50:31: error: call to '__open_missing_mode' declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
   50 |           __open_missing_mode ();
      |           ~~~~~~~~~~~~~~~~~~~~^~
```

Since this is a lock file for the transaction only managed by this
application, it makes sense to set the mode to be writable by the
the user running the process and nothing else, thus `600`.