### PR TITLE
Don't copy /run/systemd/resolve itself (fixes #70)

### DIFF
--- a/lib/Transaction.cpp
+++ b/lib/Transaction.cpp
@@ -165,7 +165,8 @@ void Transaction::impl::addSupplements() {
     }
     supplements.addLink(fs::path{"../../usr/lib/sysimage/rpm"}, fs::path{"/var/lib/rpm"});
     supplements.addFile(fs::path{"/run/netconfig"});
-    supplements.addFile(fs::path{"/run/systemd/resolve"});
+    supplements.addFile(fs::path{"/run/systemd/resolve/resolv.conf"});
+    supplements.addFile(fs::path{"/run/systemd/resolve/stub-resolv.conf"});
     if (fs::is_directory("/var/cache/dnf"))
         supplements.addDir(fs::path{"/var/cache/dnf"});
     if (fs::is_directory("/var/cache/yum"))


### PR DESCRIPTION
These are the two files that actually influence resolution when systemd-resolved is in use. The directory itself is not copyable (see #70).

Technically, this should be implemented as a symlink, since `/run/systemd/resolve/resolv.conf` can change at runtime, but the existing supplements methods for links (ie. `supplements.addLink`) don't seem appropriate here, and just copying the conf for the duration of the transaction is likely to be good enough in practice (indeed, it more or less matches [the old behavior](https://github.com/openSUSE/transactional-update/commit/9141d16678491f7e71ce454495e4f8970a2ec764)).