### PR TITLE
status: fix wrong sort order

### DIFF
--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -1193,8 +1193,8 @@ if [ ${DO_ROLLBACK} -eq 1 ]; then
 fi
 
 if [ "${DO_STATUS}" -eq 1 ]; then
-    for snapshot in $(ls -d /.snapshots/*/ | sort --reverse --numeric-sort); do
-	show_snapshot_status "$snapshot"
+    for snapshot in $(ls -d /.snapshots/*/ | cut -d '/' -f 3 | sort --reverse --numeric-sort); do
+	show_snapshot_status "/.snapshots/$snapshot/"
 	[ "${DO_STATUS_LAST}" -eq 1 ] && break
     done
     exit 0


### PR DESCRIPTION
System with 11 snapshots, showing the 9th as the last one:

```
localhost:~ # transactional-update status
transactional-update 4.0.0~rc2 started
Options: status
Separate /var detected.
--------------------------------------------------------------------------------
Snapshot:          9 [2022-04-21 10:18:22]
Description:       Snapshot Update of #7
(Missing status file)
--------------------------------------------------------------------------------
Snapshot:          8 [2022-04-21 07:53:12]
Description:       Snapshot Update of #7
(Missing status file)
--------------------------------------------------------------------------------
Snapshot:          7 [2022-04-20 14:41:24]
Description:       Snapshot Update of #6
(Missing status file)
--------------------------------------------------------------------------------
Snapshot:          6 [2022-04-20 09:31:14]
Description:       Snapshot Update of #5
(Missing status file)
--------------------------------------------------------------------------------
Snapshot:          5 [2022-04-20 09:28:51]
Description:       Snapshot Update of #1
(Missing status file)
--------------------------------------------------------------------------------
Snapshot:          4 [2022-04-20 09:27:22]
Description:       Snapshot Update of #1
(Missing status file)
--------------------------------------------------------------------------------
Snapshot:          3 [2022-04-20 07:56:02]
Description:       Snapshot Update of #2
(Missing status file)
--------------------------------------------------------------------------------
Snapshot:          2 [2022-04-20 07:34:20]
Description:       Snapshot Update of #1
(Missing status file)
--------------------------------------------------------------------------------
Snapshot:          11* [2022-04-21 13:19:39]
Description:       Snapshot Update of #1
(Missing status file)
--------------------------------------------------------------------------------
Snapshot:          10 [2022-04-21 12:03:15]
Description:       Snapshot Update of #9
(Missing status file)
--------------------------------------------------------------------------------
Snapshot:          1 [2022-04-17 08:37:41]
Description:       first root filesystem
(Missing status file)
```