### PR TITLE
Fix building with GCC 12.

### DIFF
--- a/lib/Bindings/CBindings.cpp
+++ b/lib/Bindings/CBindings.cpp
@@ -11,6 +11,7 @@
 #include <exception>
 #include <thread>
 #include <string.h>
+#include <vector>
 
 using namespace TransactionalUpdate;
 thread_local std::string errmsg;


### PR DESCRIPTION
Fixes the following error:
Bindings/CBindings.cpp:171:28: error: 'vector' in namespace 'std' does not name a template type