### PR TITLE
Fix typo in logrotate config file

### DIFF
--- a/logrotate/transactional-update
+++ b/logrotate/transactional-update
@@ -1,4 +1,4 @@
-/var/log/transactional.log {
+/var/log/transactional-update.log {
     compress
     dateext
     notifempty


### PR DESCRIPTION
There is a typo in transactional-update's logrotate config file (/usr/etc/logrotate.d/transactional-update) that prevents logrotate from actually rotating tu's log file in /var/log/transacitonal-update.log.