### PR TITLE
Two simple create_dirs_from_rpmdb fixes

### DIFF
--- a/sbin/create_dirs_from_rpmdb.c
+++ b/sbin/create_dirs_from_rpmdb.c
@@ -441,7 +441,7 @@ int main(int argc, char *argv[]) {
     /* XXX missing: free list */
 
     /* Can't do anything if this fails anyway. */
-    if (rpmdb_cookie)
+    if (ec == 0 && rpmdb_cookie)
         rpmCookieWrite(rpmdb_cookie);
 
     rpmdbFreeIterator(mi);

--- a/sbin/create_dirs_from_rpmdb.c
+++ b/sbin/create_dirs_from_rpmdb.c
@@ -265,6 +265,11 @@ int create_dirs(struct node *node, size_t size) {
         /* set selinux file context */
         if (use_selinux) {
             if (selabel_lookup_raw(hnd, &newcon, node->dirname, node->fmode) < 0) {
+                if (errno == ENOENT) {
+                    fprintf(stderr, "Warning: No default context for directory '%s'\n", node->dirname);
+                    continue;
+                }
+
                 fprintf(stderr, "Failed to get default context for directory '%s': %m\n", node->dirname);
                 rmdir(node->dirname);
                 rc = 1;


### PR DESCRIPTION
* [create_dirs_from_rpmdb: Just warn if no default SELinux context found](https://github.com/openSUSE/transactional-update/commit/4e3c79996a37042be7a4f7803599b82465b6de6c)
Don't error out if a directory doesn't have a default SELinux context
assigned. Like restorecon, just show a warning and continue without assigning
a context (boo#1188215).
* [create_dirs_from_rpmdb: Don't update the rpmdb cookie on failure](https://github.com/openSUSE/transactional-update/commit/8c25b73aaeeb7b35074e244e6160c435592ff217) 
If the operation failed, the next invocation should try again instead of
exiting early.