### PR TITLE
Handle directories owned by multiple packages (bsc#1188215)

### DIFF
--- a/sbin/create_dirs_from_rpmdb.c
+++ b/sbin/create_dirs_from_rpmdb.c
@@ -243,6 +243,30 @@ int create_dirs(struct node *node, size_t size) {
             {.tv_sec = node->fmtime, .tv_usec = 0},
             {.tv_sec = node->fmtime, .tv_usec = 0}};
 
+        /* Check whether the directory was already handled.
+         * The list is sorted, so only the previous one needs to be checked. */
+        if (i > 0 && strcmp(node[-1].dirname, node[0].dirname) == 0) {
+            struct node *last = &node[-1];
+            if (debug_flag)
+                printf("%s already seen\n", node->dirname);
+
+            if (last->user_id != node->user_id || last->group_id != node->group_id)
+                fprintf(stderr, "Warning: Conflicting owners (%ld:%ld and %ld:%ld) for %s\n",
+                        (long)last->user_id, (long)last->group_id,
+                        (long)node->user_id, (long)node->group_id,
+                        node->dirname);
+
+            if (last->fmode != node->fmode) {
+                char *lastperms = fmode2str(last->fmode), *nodeperms = fmode2str(node->fmode);
+                fprintf(stderr, "Warning: Conflicting modes (%s and %s) for %s\n",
+                        lastperms, nodeperms, node->dirname);
+                free(lastperms);
+                free(nodeperms);
+            }
+
+            continue;
+        }
+
         if (verbose_flag)
             printf("Create %s\n", node->dirname);
 


### PR DESCRIPTION
It's possible (and valid) that a directory is owned by multiple packages.
Instead of trying to create those multiple times (and failing with EEXIST),
only create it once. Complain if ownership or mode don't match, but continue
anyway, like RPM.

Can be reproduced easily by installing `postgresql1X-server`, as both the versioned and the unversioned (`postgresql-server`) packag own `/var/lib/pgsql`.

Before:
```
localhost:~ # rm -rf /var/lib/pgsql; ./create_dirs_from_rpmdb --debug --verbose
Missing /var/lib/pgsql (drwxr-x---,postgres,postgres,2022-07-13,12:27)
Missing /var/lib/pgsql (drwxr-x---,postgres,postgres,2022-08-16,15:23)
Create /var/lib/pgsql
Set SELinux file context to system_u:object_r:postgresql_db_t:s0
Create /var/lib/pgsql
Failed to create directory '/var/lib/pgsql': File exists
```

After:
```
localhost:~ # rm -rf /var/lib/pgsql; ./create_dirs_from_rpmdb --debug --verbose
Missing /var/lib/pgsql (drwxr-x---,postgres,postgres,2022-07-13,12:27)
Missing /var/lib/pgsql (drwxr-x---,postgres,postgres,2022-08-16,15:23)
Create /var/lib/pgsql
Set SELinux file context to system_u:object_r:postgresql_db_t:s0
/var/lib/pgsql already seen
```

With some intentional conflicts introduced:

```
localhost:~ # rm -rf /var/lib/pgsql; ./create_dirs_from_rpmdb --debug --verbose
Missing /var/lib/pgsql (drwxr-x---,postgres,postgres,2022-08-22,13:35)
Missing /var/lib/pgsql (drwxrwx---,root,root,2022-08-22,13:35)
Missing /var/lib/pgsql (drwxr-x---,postgres,postgres,2022-07-13,12:27)
Missing /var/lib/pgsql (drwxr-x---,postgres,postgres,2022-08-16,15:23)
Create /var/lib/pgsql
Set SELinux file context to system_u:object_r:postgresql_db_t:s0
/var/lib/pgsql already seen
Warning: Conflicting owners (473:473 and 0:0) for /var/lib/pgsql
Warning: Conflicting modes (drwxr-x--- and drwxrwx---) for /var/lib/pgsql
/var/lib/pgsql already seen
Warning: Conflicting owners (0:0 and 473:473) for /var/lib/pgsql
Warning: Conflicting modes (drwxrwx--- and drwxr-x---) for /var/lib/pgsql
/var/lib/pgsql already seen
```