### PR TITLE
Feature/notify method

### DIFF
--- a/doc/transactional-update.xml
+++ b/doc/transactional-update.xml
@@ -163,7 +163,7 @@
 	For these systems transactional-updates provides automatic
 	updates; snapshots with failed updates will be automatically removed.
 	Automatic reboots can be triggered using a variety of different reboot
-	methods (e.g. rebootmgr, kured or systemd), making the appliance of
+	methods (e.g. rebootmgr, notify, kured or systemd), making the appliance of
 	the updates cluster aware.
       </para>
       <para>

--- a/etc/transactional-update.conf
+++ b/etc/transactional-update.conf
@@ -2,7 +2,7 @@
 # See transactional-update.conf(5) for details
 
 # Reboot method
-# Valid values: auto salt rebootmgr systemd kexec none
+# Valid values: auto salt rebootmgr notify systemd kexec none
 #REBOOT_METHOD=auto
 
 # zypper update method

--- a/lib/Reboot.cpp
+++ b/lib/Reboot.cpp
@@ -29,6 +29,8 @@ Reboot::Reboot(std::string method) {
 
     if (method == "rebootmgr") {
         command  = "/usr/sbin/rebootmgrctl reboot";
+    } else if (method == "notify") {
+        command  = "/usr/bin/transactional-update-notifier client";
     } else if (method == "systemd") {
         command  = "sync;";
         command += "systemctl reboot;";

--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -1539,6 +1539,9 @@ if [ ${EXITCODE} -eq 0 ]; then
 	    rebootmgr)
 		reboot_via_rebootmgr
 		;;
+	    notify)
+		reboot_via_notify
+		;;
 	    systemd)
 		reboot_via_systemd
 		;;

--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -299,6 +299,11 @@ reboot_via_rebootmgr() {
     tukit reboot rebootmgr |& tee -a ${LOGFILE}
 }
 
+reboot_via_notify() {
+    TELEM_PAYLOAD="${TELEM_PAYLOAD}\nreboot=transactional-update-notify client"
+    tukit reboot notify |& tee -a ${LOGFILE}
+}
+
 reboot_via_systemd() {
     TELEM_PAYLOAD="${TELEM_PAYLOAD}\nreboot=systemctl reboot"
     tukit reboot systemd |& tee -a ${LOGFILE}

--- a/systemd/transactional-update.timer
+++ b/systemd/transactional-update.timer
@@ -7,6 +7,7 @@ After=network.target local-fs.target
 OnCalendar=daily
 AccuracySec=1m
 RandomizedDelaySec=2h
+Persistent=true
 
 [Install]
 WantedBy=timers.target

--- a/tukit/tukit.cpp
+++ b/tukit/tukit.cpp
@@ -64,7 +64,7 @@ void TUKit::displayHelp() {
     cout << "                             List of fields to print\n";
     cout << "\n";
     cout << "Reboot Commands:\n";
-    cout << "reboot [auto|rebootmgr|systemd|kured|kexec]\n";
+    cout << "reboot [auto|rebootmgr|notify|systemd|kured|kexec]\n";
     cout << "\tReboot the system using the given method; Default: auto\n";
     cout << "\n";
     cout << "Generic Options:\n";


### PR DESCRIPTION
Hi all,

As discussed in the mailing list here: https://lists.opensuse.org/archives/list/kubic@lists.opensuse.org/thread/E6ZYOXFKRM5BODY25PEWZRBCMEFYS66W/

This pull request aims to add a notify method (`reboot_via_notify`) so that on MicroOS Desktop setups we can let the user know that the t-u timer applied updates successfully.
This should be a more suitable way to apply updates automatically on desktop setups where 3:30am reboots are not advisable.

This PR also adds `Persistent=true` to the systemd-timer, in order to ensure that updates are performed if the machine is in sleep/shutdown during the timer window.

This PR goes in hand with this other tool: https://github.com/89luca89/transactional-update-notifier
Which is the client/server app that is called by the `reboot_via_notify` method, in order to sent notifications to all logged user graphically.

To summarize this PR implements:

- a new `reboot_via_notify` method in the t-u script
- the correspondent reboot method to `Reboot.cpp`
- persistence to the systemd-timer

Also the notifier tool supports reporting faliures, we can evaluate if using this feature or not in the t-u script

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>