### PR TITLE
Don't leave source for overlay syncing mounted

### DIFF
--- a/lib/Overlay.cpp
+++ b/lib/Overlay.cpp
@@ -104,7 +104,7 @@ void Overlay::sync(string base, fs::path snapRoot) {
         tulog.info("Parent snapshot ", previousSnapId, " does not exist any more - skipping rsync");
         return;
     }
-    unique_ptr<Mount> previousEtc{new Mount("/etc")};
+    unique_ptr<Mount> previousEtc{new Mount("/etc", 0, true)};
     previousEtc->setTabSource(previousSnapshot->getRoot() / "etc" / "fstab");
 
     // Mount read-only, so mount everything as lowerdir


### PR DESCRIPTION
Explicitly tell it to unmount on return.

IMO `Mount` should at least default to `unmount=true`. The interface should also be changed so that it's a mandatory parameter to the `mount` method. It doesn't make sense to have to specify this if the `Mount` object is not actually mounted and it should also be set when it's actually mounted and not several lines above or below.