### PR TITLE
rollback: fix syntax error

### DIFF
--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -1197,7 +1197,7 @@ if [ ${DO_ROLLBACK} -eq 1 ]; then
 	    check_registration_on_next_reboot
 	fi
 	# Remove possible cleanup algo and re-add to list
-	if ! \( echo "${LAST_WORKING_SNAPSHOTS} ${UNUSED_SNAPSHOTS}" | grep --word-regexp --quiet "${ROLLBACK_SNAPSHOT}" \); then
+	if ! ( echo "${LAST_WORKING_SNAPSHOTS} ${UNUSED_SNAPSHOTS}" | grep --word-regexp --quiet "${ROLLBACK_SNAPSHOT}" ); then
 	    UNUSED_SNAPSHOTS="${UNUSED_SNAPSHOTS} ${ROLLBACK_SNAPSHOT}"
 	    save_state_file 0
 	fi


### PR DESCRIPTION
I came across this while trying the master version (renamed as 4.1.5 to satisfy spec requires).

```
localhost:~ # transactional-update rollback 1
transactional-update 4.1.5 started
Options: rollback 1
Separate /var detected.
Rollback to snapshot 1...
/sbin/transactional-update: line 1200: (: command not found
grep: ): No such file or directory
Please reboot to finish rollback!
```