### PR TITLE
Add support for full syntax sub commands

### DIFF
--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -871,13 +871,13 @@ while [ 1 ]; do
 	    DO_CLEANUP_OVERLAYS=1
 	    shift
 	    ;;
-	dup)
+	dist-upgrade|dup)
 	    DO_DUP=1
 	    ZYPPER_ARG="--no-cd dup"
 	    shift
 	    TELEM_CLASS="upgrade"
 	    ;;
-        up)
+        update|up)
 	    ZYPPER_ARG=up
 	    shift
 	    TELEM_CLASS="update"


### PR DESCRIPTION
Some sub commands like `pkg` also have `package`. And since the `up` sub command is based on `zypper up`, which is an alias for `update`, I thought of adding both `up` and `update` to this command.

I left the docs as is, since it's just to make sure people don't run into this mistake or expect this behavior as they can for other sub commands and in `zypper`. I also did the same for `dup` with the same reasoning.