### PR TITLE
tukit: enable kexec's syscall detection feature

### DIFF
--- a/lib/Reboot.cpp
+++ b/lib/Reboot.cpp
@@ -37,7 +37,7 @@ Reboot::Reboot(std::string method) {
     } else if (method == "kured") {
         command  = "touch /var/run/reboot-required";
     } else if (method == "kexec") {
-        command  = "kexec -l /boot/vmlinuz --initrd=/boot/initrd --reuse-cmdline;";
+        command  = "kexec -a -l /boot/vmlinuz --initrd=/boot/initrd --reuse-cmdline;";
         command += "sync;";
         command += "systemctl kexec;";
     } else if (method == "none") {

--- a/lib/Reboot.cpp
+++ b/lib/Reboot.cpp
@@ -37,7 +37,7 @@ Reboot::Reboot(std::string method) {
     } else if (method == "kured") {
         command  = "touch /var/run/reboot-required";
     } else if (method == "kexec") {
-        command  = "kexec -a -l /boot/vmlinuz --initrd=/boot/initrd --reuse-cmdline;";
+        command  = "kexec --kexec-syscall-auto -l /boot/vmlinuz --initrd=/boot/initrd --reuse-cmdline;";
         command += "sync;";
         command += "systemctl kexec;";
     } else if (method == "none") {


### PR DESCRIPTION
On system with lockdown enabled, the kexec_load syscall can't be used since it doesn't support signature verification, and one need to use the file based syscall for kexec operation.

Luckily the kexec has a `-a`/`--kexec-syscall-auto` option that handles this situation since mid-2018 and becomes the default recently with horms/kexec-tools@29fe5067ed. To ensure that the auto detection is always used even with older kexec-tools, let's just alway specify the -a argument to kexec.