### PR TITLE
Adding support for performing updates from a container image

### DIFF
--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -32,6 +32,7 @@ REWRITE_GRUB_CFG_NO_REBOOT=0
 REWRITE_INITRD=0
 REBUILD_KDUMP_INITRD=0
 DO_APPLY=0
+DO_APPLY_OCI=0
 DO_CLEANUP_OVERLAYS=0
 DO_CLEANUP_SNAPSHOTS=0
 DO_MIGRATION=0
@@ -74,6 +75,9 @@ SYSTEM_MANIFEST_FILE="@libdir@/sysimage/tu/system.manifest"
 ZYPPER_AUTO_IMPORT_KEYS=0
 ETC_OVERLAY_PATTERN='^[^[:space:]]\+[[:space:]]\+\/etc[[:space:]]\+overlay[[:space:]]\+\([^[:space:]]*,\|\)workdir=\/sysroot\/var\/lib\/overlay\/work-etc[,[:space:]]'
 NON_ROOTFS_WHITELIST=("/var/lib/YaST2/cookies" "/var/lib/rpm" "/var/lib/systemd/migrated" "/var/run/zypp.pid")
+OCI_RSYNC_ARGS="-a --hard-links --xattrs --acls --inplace"
+OCI_RSYNC_EXCLUDES="/etc /var /usr/local /tmp /root /home /srv /opt /sys /dev /proc /run"
+OCI_TARGET=""
 DRACUT_OPTS=""
 TUKIT_OPTS=""
 
@@ -173,6 +177,7 @@ usage() {
     echo "pkg install|in ...         Install individual packages (i)"
     echo "pkg remove|rm ...          Remove individual packages (i)"
     echo "pkg update|up ...          Updates individual packages (i)"
+    echo "apply-oci ...              Applies system layout based on OCI container (i)"
     echo "register ...               Register system via SUSEConnect (implies -d)"
     echo ""
     echo "Standalone Commands:"
@@ -1088,6 +1093,38 @@ parse_args() {
 		# A lot of commands won't change anything; discard snapshot then
 		TUKIT_OPTS="${TUKIT_OPTS} --discard"
 		;;
+	    apply-oci)
+		DO_APPLY_OCI=1
+		REWRITE_GRUB_CFG=1
+		REWRITE_INITRD=1
+		REBUILD_KDUMP_INITRD=1
+		shift
+
+		if [ $# -eq 0 ]; then
+		    usage 1
+		fi
+
+		while [ 1 ]; do
+		    if [ $# -eq 0 ]; then
+			break;
+		    else
+			if [ "$1" == "--image" ]; then
+			    if [ -n "$2" ]; then
+				OCI_TARGET=$2
+			    else
+				log_error "ERROR: Please specify an OCI image to use as an upgrade target."
+				quit 1
+			    fi
+			fi
+			if [ "$1" == "--help" ]; then
+			    usage 1
+			    break
+			fi
+		        shift
+		    fi
+		done
+		shift
+		;;
 	    -h|--help)
 		usage 0
 		;;
@@ -1435,7 +1472,8 @@ fi
 if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
     -o ${REWRITE_INITRD} -eq 1 -o ${REBUILD_KDUMP_INITRD} -eq 1 \
     -o ${RUN_SHELL} -eq 1 -o ${DO_RUN} -eq 1 \
-    -o ${REWRITE_BOOTLOADER} -eq 1 -o ${DO_REGISTRATION} -eq 1 ]; then
+    -o ${REWRITE_BOOTLOADER} -eq 1 -o ${DO_REGISTRATION} -eq 1 \
+    -o ${DO_APPLY_OCI} -eq 1 ]; then
 
     if [ -z "${ZYPPER_NONINTERACTIVE}" -a "${DEFAULT_SNAPSHOT_ID}" -ne "${BASE_SNAPSHOT_ID}" ]; then
 	log_info "WARNING: You are creating a snapshot from a different base (${BASE_SNAPSHOT_ID}) than the"
@@ -1463,6 +1501,36 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
     if [ ${DO_REGISTRATION} -eq 1 ]; then
 	tukit ${TUKIT_OPTS} callext ${SNAPSHOT_ID} SUSEConnect --root {} ${REGISTRATION_ARGS} |& tee -a ${LOGFILE} 1>&${origstdout}
 	set_reboot_level "soft-reboot"
+    fi
+
+    if [ ${DO_APPLY_OCI} -eq 1 ]; then
+	# Pull desired container image and mount it ready for copy
+	log_info "INFO: Pulling image from: $OCI_TARGET"
+	podman image pull $OCI_TARGET || {
+	    log_error "ERROR: Couldn't pull image from $OCI_TARGET"
+	    quit 1
+	}
+	OCI_MOUNT=$(podman image mount $OCI_TARGET)
+
+	# Copy over core parts of the operating system into the new snapshot, deleting files that don't exist, and ignoring partitions that aren't captured in the snapshot
+	log_info "INFO: Writing contents of ${OCI_TARGET} to snapshot directory ${SNAPSHOT_DIR}..."
+	OCI_RSYNC_EXCLUDES_LIST=()
+	for i in ${OCI_RSYNC_EXCLUDES}; do
+	    OCI_RSYNC_EXCLUDES_LIST+=("--exclude $i ")
+	done
+	rsync --delete ${OCI_RSYNC_ARGS} ${OCI_RSYNC_EXCLUDES_LIST[@]} ${OCI_MOUNT}/ ${SNAPSHOT_DIR}/ |& tee -a ${LOGFILE} 1>&${origstdout}
+
+	# Merge contents of /etc from container image but preserve existing configuration
+	log_info "INFO: Merging /etc from container image into existing snapshot, preserving existing configuration..."
+	tukit ${TUKIT_OPTS} callext ${SNAPSHOT_ID} rsync --ignore-existing ${OCI_RSYNC_ARGS} ${OCI_MOUNT}/etc/ ${SNAPSHOT_DIR}/etc/ |& tee -a ${LOGFILE} 1>&${origstdout}
+
+	# Unmount the container image
+	podman image unmount ${OCI_TARGET}
+	# Ensure that the filesystem is labelled correctly for SELinux.
+	log_info "Forcing SELinux relabel at next reboot."
+	touch ${SNAPSHOT_DIR}/.autorelabel
+	# Ensure RPM database is using the desired system backend
+	tukit ${TUKIT_OPTS} call ${SNAPSHOT_ID} rpm --rebuilddb |& tee -a ${LOGFILE} 1>&${origstdout}
     fi
 
     if [ -n "${ZYPPER_ARG}" ]; then


### PR DESCRIPTION
In this PR I'm introducing support for `transactional-update` to be able to consume a container image (or OCI artefact) as the source for the next boot snapshot. This is very important functionality that allows customers to build, distribute, and validate their operating system images via a standardised container image workflow; they can build OS images via Dockerfiles, store and retrieve them via a standard image registry, and put them through standard SBOM and vulnerability checkers.

This PR is specifically addressing requirements to enable customers to upgrade an existing machine, regardless of how it was deployed, to a new image-based snapshot, however the initial day1 approach could use tooling such as `kiwi-ng system stackbuild` to build bootable raw and SelfInstall ISO's based on the same container image, which is already a supported feature.

The approach taken in this PR:

* Enables an easy on-ramp (and off-ramp) for users wanting to use the image approach
* Leverages existing standard tooling to achieve the workflow; this would just use the standard OS layout/tools.
* Enables users to switch between standard package or image based upgrades (no need to build a new image every time)
* Doesn't break existing workflow for patching or migrating between products
* Retains full `snapper` (i.e. `transactional-update rollback`) functionality
* Retains full customisation options through ignition/combustion and `jeos-firstboot` (provided they're in the image!)
* Preserves existing user configuration between updates/rollbacks [1]

I could use some help with ensuring that I'm making the correct calls, as I'm mixing `tukit callext` with using the `{SNAPSHOT_DIR}` directly. I suspect there's a more elegant/safer/better way of achieving this, hence why it's labelled as a work in progress for now.

Further, we likely need to run some validations to make sure that the target image is actually bootable. This code forces a `dracut` and `grub2-mkconfig` run, but I can see this being an area where it may be trivial to make the system difficult to boot and rescue. I'm not an expert here, so I'm wondering whether there are checks that we could execute, and if they fail, we can abort the snapshot. Documentation on how to build an image will be very important, especially as it relates to partitions (or btrfs subvolumes that are ignored) but we should likely do some additional sanity checks to verify the state of the new snapshot rather than blindly closing it and enabling the user to reboot, where we're not able to provide a decent level of confidence in a successful reboot.

For testing, I used this on-top of SLE Micro 5.5 and used a test container image available at (`registry.opensuse.org/home/roxenham/slemicro/containers/edge/sle-micro/5.5:20240726`). This is a very simple image that aims to mirror the standard SLE Micro 5.5 packages as defined in the original Kiwi image definition file, i.e. it's not cut down, but has the bare set of packages typically installed, or as defined in the "Default" profile. Of course, it's perfectly possible to modify this image to suit, e.g. adding a package to it is as simple as building and pushing a new image (noting that the `suseconnect` is only required for commercially registered images, this wouldn't be required for Leap Micro or MicroOS:

```
% cat Dockerfile
FROM registry.opensuse.org/home/roxenham/slemicro/containers/edge/sle-micro/5.5:20240726
RUN suseconnect -r <regcode> && zypper --gpg-auto-import-keys ref \
     && zypper in -y nvidia-open-driver-G06-signed-kmp-default \
     && suseconnect -d && zypper clean -a

ARG IMAGE_REPO=unknown
ARG IMAGE=unknown
ARG IMAGE_TAG=unknown

RUN sed -i '/IMAGE/d' /usr/lib/os-release && \
    sed -i '/TIMESTAMP/d' /usr/lib/os-release && \
    echo IMAGE_REPO=\"$IMAGE_REPO\"              >> /usr/lib/os-release && \
    echo IMAGE_TAG=\"$IMAGE_TAG\"                >> /usr/lib/os-release && \
    echo IMAGE=\"$IMAGE_REPO:$IMAGE_TAG\"        >> /usr/lib/os-release && \
    echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`"      >> /usr/lib/os-release

% podman build -t harbor.rancher.rdoxenham.com/slemicro/5.5:$(date +'%Y%m%d') \
    --build-arg "IMAGE=harbor.rancher.rdoxenham.com/slemicro/5.5:$(date +'%Y%m%d')" \
    --build-arg "IMAGE_TAG=$(date +'%Y%m%d')" \
    --build-arg "IMAGE_REPO=harbor.rancher.rdoxenham.com/slemicro/5.5" .

% podman push harbor.rancher.rdoxenham.com/slemicro/5.5:20240727
(...)
```

Then, this image can be used as an input to code provided as part of this PR:

```
# transactional-update apply-oci --image harbor.rancher.rdoxenham.com/slemicro/5.5:20240727
(...)

[after reboot]

# cat /etc/os-release
NAME="SLE Micro"
VERSION="5.5"
VERSION_ID="5.5"
PRETTY_NAME="SUSE Linux Enterprise Micro 5.5"
ID="sle-micro"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sle-micro:5.5"
GRUB_ENTRY_NAME="SLE Micro"
IMAGE_REPO="harbor.rancher.rdoxenham.com/slemicro/5.5"
IMAGE_TAG="20240727"
IMAGE="harbor.rancher.rdoxenham.com/slemicro/5.5:20240727"
TIMESTAMP=20240727173117

# rpm -qa | grep nvidia-open-driver
nvidia-open-driver-G06-signed-kmp-default-550.90.07_k5.14.21_150500.55.65-150500.3.47.1.x86_64
```

**Some further guidance from the TU community would be appreciated. Thanks a lot!**

[1] This approach aligns well with the `bootc` project (https://containers.github.io/bootc/filesystem.html#etc) to be able to persist `/etc` configuration across image updates, which would enable configuration such as OS registration, package repositories, static network configuration, and various other components to persist, and not be overwritten by the OS upgrade. However, one question we may want to answer is whether we want to enable `/usr/etc` to enable specific files in `/etc` to be overwritten by force by contents found in `/usr/etc` to give users a release-valve for changing certain persistent configuration over time as part of a 3-way merge (this PR doesn't do this yet).

