### PR TITLE
Fail when "transactional-update run" command returns non-zero exit code

### DIFF
--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -1739,6 +1739,10 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 
     if [ ${DO_RUN} -eq 1 ]; then
 	tukit ${TUKIT_OPTS} call "${SNAPSHOT_ID}" "${RUN_CMD[@]}" |& tee -a ${LOGFILE} 1>&${origstdout}
+	if [ ${PIPESTATUS[0]} -ne 0 ]; then
+	    log_error "ERROR: ${RUN_CMD[@]} failed!"
+	    EXITCODE=1;
+	fi
 	set_reboot_level "reboot"
     fi
 


### PR DESCRIPTION
closes: #134

Example with suggested changes:
```bash
# transactional-update run ls /foo/bar
Checking for newer version.
transactional-update  started
Options: run ls /foo/bar
Separate /var detected.
2024-10-16 08:29:50 tukit 4.8.1 started
2024-10-16 08:29:50 Options: -c4 open 
2024-10-16 08:29:51 Using snapshot 4 as base for new snapshot 16.
2024-10-16 08:29:51 /var/lib/overlay/4/etc
2024-10-16 08:29:51 Syncing /etc of previous snapshot 3 as base into new snapshot "/.snapshots/16/snapshot"
2024-10-16 08:29:51 SELinux is enabled.
ID: 16
2024-10-16 08:29:52 Transaction completed.
2024-10-16 08:29:52 tukit 4.8.1 started
2024-10-16 08:29:52 Options: call 16 ls /foo/bar 
2024-10-16 08:29:52 Executing `ls /foo/bar`:
ls: cannot access '/foo/bar': No such file or directory
2024-10-16 08:29:52 Application returned with exit status 2.
ERROR: ls /foo/bar failed!
Removing snapshot #16...
2024-10-16 08:29:52 tukit 4.8.1 started
2024-10-16 08:29:52 Options: abort 16 
2024-10-16 08:29:53 Discarding snapshot 16.
2024-10-16 08:29:54 Transaction completed.
transactional-update finished

# echo $?
1
```

Note: For consistency with the other code base the `EXITCODE` is always set to `1` when a `RUN_CMD` fails.

Feel free to close this if I have missed something and this is the intended behaviour.