### PR TITLE
Add container-snap

### DIFF
--- a/etc/tukit.conf
+++ b/etc/tukit.conf
@@ -12,6 +12,9 @@
 # self-contained.
 BINDDIRS[0]="/opt"
 
+# container-snap "snapshots"
+BINDDIRS[1]="/var/lib/container-snap"
+
 # For "rebootmgr" and "systemd" reboot methods, allow them to use
 # systemd's soft-reboot mechanism if /run/reboot-needed indicates this
 # would be sufficient (see man 8 zypp-boot-plugin).

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS = subdir-objects
 lib_LTLIBRARIES = libtukit.la
 libtukit_la_SOURCES=Transaction.cpp \
-        SnapshotManager.cpp Snapshot/Snapper.cpp \
+        SnapshotManager.cpp Snapshot/Snapper.cpp Snapshot/ContainerSnap.cpp \
         Mount.cpp Overlay.cpp Reboot.cpp Configuration.cpp \
         Util.cpp Supplement.cpp Plugins.cpp Bindings/CBindings.cpp \
         BlsEntry.cpp
@@ -9,7 +9,7 @@ publicheadersdir=$(includedir)/tukit
 publicheaders_HEADERS=Transaction.hpp \
 	SnapshotManager.hpp Reboot.hpp \
 	Bindings/libtukit.h
-noinst_HEADERS=Snapshot/Snapper.hpp Snapshot.hpp \
+noinst_HEADERS=Snapshot/Snapper.hpp Snapshot/ContainerSnap.hpp Snapshot.hpp \
         Mount.hpp Overlay.hpp Log.hpp Configuration.hpp \
         Util.hpp Supplement.hpp Exceptions.hpp Plugins.hpp BlsEntry.hpp
 libtukit_la_CPPFLAGS=-DPREFIX=\"$(prefix)\" -DCONFDIR=\"$(sysconfdir)\" $(ECONF_CFLAGS) $(LIBMOUNT_CFLAGS) $(SELINUX_CFLAGS)

--- a/lib/Snapshot/ContainerSnap.cpp
+++ b/lib/Snapshot/ContainerSnap.cpp
@@ -1,0 +1,100 @@
+#include "ContainerSnap.hpp"
+#include "Util.hpp"
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace TransactionalUpdate {
+
+static std::string callContainerSnap(std::string opts) {
+  std::string output;
+
+  output = Util::exec("container-snap " + opts);
+  Util::trim(output);
+  return output;
+}
+
+std::string ContainerSnap::getCurrent() {
+  return callContainerSnap("get-current");
+}
+
+std::string ContainerSnap::getDefault() {
+  return callContainerSnap("get-default");
+}
+
+void ContainerSnap::deleteSnap(std::string id) {
+  callContainerSnap("delete --id=" + id);
+}
+
+void ContainerSnap::rollbackTo(std::string id) {
+  callContainerSnap("switch " + id);
+}
+
+std::deque<std::map<std::string, std::string>>
+ContainerSnap::getList(std::string columns) {
+  std::deque<std::map<std::string, std::string>> snapshotList;
+
+  const auto output = callContainerSnap("list-snapshots");
+  std::stringstream outputstream(output);
+  std::string line;
+
+  while (std::getline(outputstream, line)) {
+    std::stringstream linestream(line);
+
+    std::string id, ro;
+    std::getline(linestream, id, ',');
+
+    if (id[0] == '#') {
+      continue;
+    }
+
+    std::getline(linestream, ro);
+
+    std::map<std::string, std::string> entry = {{"id", id}, {"ro", ro}};
+    snapshotList.push_back(entry);
+  }
+
+  return snapshotList;
+}
+
+std::unique_ptr<Snapshot> ContainerSnap::open(std::string id) {
+  return std::make_unique<ContainerSnapshot>(ContainerSnapshot(id));
+};
+
+std::unique_ptr<Snapshot> ContainerSnap::create(std::string base,
+                                                std::string /*description*/) {
+  std::string new_snapshot_id = callContainerSnap("create-snapshot " + base);
+  return std::make_unique<ContainerSnapshot>(
+      ContainerSnapshot(new_snapshot_id));
+}
+
+std::filesystem::path ContainerSnapshot::getRoot() {
+  return std::filesystem::path(
+      callContainerSnap("get-root " + this->snapshotId));
+}
+
+void ContainerSnapshot::abort() {
+  ContainerSnap().deleteSnap(this->snapshotId);
+}
+
+void ContainerSnapshot::close() { this->inProgress = false; }
+
+bool ContainerSnapshot::isInProgress() { return this->inProgress; }
+
+bool ContainerSnapshot::isReadOnly() {
+  return callContainerSnap("get-readonly-state " + this->snapshotId) == "true";
+}
+
+void ContainerSnapshot::setDefault() {
+  callContainerSnap("switch " + this->snapshotId);
+}
+
+void ContainerSnapshot::setReadOnly(bool readonly) {
+  callContainerSnap("set-readonly-state " +
+                    std::string(readonly ? "--readonly" : "--no-readonly") +
+                    " " + this->snapshotId);
+}
+
+} // namespace TransactionalUpdate

--- a/lib/Snapshot/ContainerSnap.hpp
+++ b/lib/Snapshot/ContainerSnap.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-FileCopyrightText: 2020 SUSE LLC */
+
+#include "Snapshot.hpp"
+#include "SnapshotManager.hpp"
+
+namespace TransactionalUpdate {
+
+class ContainerSnap : public SnapshotManager {
+public:
+  ~ContainerSnap() = default;
+
+  ContainerSnap() : SnapshotManager() {};
+  std::unique_ptr<Snapshot> create(std::string base,
+                                   std::string description) override;
+  virtual std::unique_ptr<Snapshot> open(std::string id) override;
+
+  /** Returns the list of snapshots, ignores the input columns (unsupported by
+   * container-snap)
+   */
+  std::deque<std::map<std::string, std::string>>
+  getList(std::string columns) override;
+  std::string getCurrent() override;
+  std::string getDefault() override;
+  void deleteSnap(std::string id) override;
+  void rollbackTo(std::string id) override;
+};
+
+class ContainerSnapshot : public Snapshot {
+private:
+  bool inProgress = true;
+
+public:
+  ~ContainerSnapshot() = default;
+
+  ContainerSnapshot(std::string snap) : Snapshot(snap) {};
+  void close() override;
+  void abort() override;
+  std::filesystem::path getRoot() override;
+  bool isInProgress() override;
+  bool isReadOnly() override;
+  void setDefault() override;
+  void setReadOnly(bool readonly) override;
+};
+
+} // namespace TransactionalUpdate

--- a/lib/SnapshotManager.cpp
+++ b/lib/SnapshotManager.cpp
@@ -6,7 +6,9 @@
   implementations can be found in the "Snapshot" directory
  */
 
+#include "Snapshot/ContainerSnap.hpp"
 #include "Snapshot/Snapper.hpp"
+#include <memory>
 using namespace std;
 
 namespace TransactionalUpdate {
@@ -15,6 +17,8 @@ namespace TransactionalUpdate {
 unique_ptr<SnapshotManager> SnapshotFactory::get() {
     if (filesystem::exists("/usr/bin/snapper")) {
         return make_unique<Snapper>();
+    } else if (filesystem::exists("/usr/bin/container-snap")) {
+      return make_unique<ContainerSnap>();
     } else {
         throw runtime_error{"No supported environment found."};
     }


### PR DESCRIPTION
This is a draft PR to add support for [container-snap](https://github.com/dcermak/container-snap), a highly experimental deployment tool of OCI images (this is comparable to #128, but uses a different mechanism).

The current implementation "works" to reboot into a snapshot based on a container image, but it's very far from being pretty or anywhere close to being end user usable.

Existing shortcomings:
- `getList` doesn't appear to work properly and is not easy to pull off, as `container-snap` doesn't support all the info that snapper does
- `getDefault` and `getCurrent` currently return the same thing (I am unsure what the difference between them is)
- `inProgress` is not really doing anything useful atm, as `container-snap` has no implementation of "in progress" (yet).