### PR TITLE
Fix check for overlayfs when using tukit open with --discard

### DIFF
--- a/lib/Transaction.cpp
+++ b/lib/Transaction.cpp
@@ -272,7 +272,8 @@ void Transaction::init(std::string base, std::optional<std::string> description)
     pImpl->addSupplements();
     if (pImpl->discardIfNoChange) {
         std::unique_ptr<Snapshot> prevSnap = pImpl->snapshotMgr->open(base);
-        std::unique_ptr<Mount> oldEtc{new Mount{prevSnap->getRoot() / "etc"}};
+        std::unique_ptr<Mount> oldEtc{new Mount{"/etc"}};
+        oldEtc->setTabSource(prevSnap->getRoot() / "etc" / "fstab");
         if (oldEtc->getFilesystem() == "overlayfs") {
             tulog.info("Can not merge back changes in /etc into old overlayfs system - ignoring 'discardIfNoChange'.");
         } else {


### PR DESCRIPTION
It used the full path to the parent snapshot's /etc for fstab lookup, which did not work:

2025-04-16 14:25:57 Discarding snapshot 2.
ERROR: File system /.snapshots/1/snapshot/etc not found in fstab.

Look for /etc in the parent snapshot's /etc/fstab.