### PR TITLE
When continuing a not yet synced snapshot, sync it

### DIFF
--- a/dracut/sync-etc-state.cpp
+++ b/dracut/sync-etc-state.cpp
@@ -383,12 +383,12 @@ int main(int argc, const char* argv[])
                     cerr << "Unsupported file type for file " << it->first << ". Skipping..." << endl;
                     continue;
                 }
-                if (lchown((parentdir / it->first).c_str(), sourcestat.stx_uid, sourcestat.stx_gid) == -1) {
+                if (lchown((currentdir / it->first).c_str(), sourcestat.stx_uid, sourcestat.stx_gid) == -1) {
                     cerr << "Error while processing " << it->first << ": ";
                     perror("lchown");
                 }
                 const struct timespec newtimes[2] = {{.tv_sec = sourcestat.stx_atime.tv_sec, .tv_nsec = sourcestat.stx_atime.tv_nsec},{.tv_sec = sourcestat.stx_mtime.tv_sec, .tv_nsec = sourcestat.stx_mtime.tv_nsec}};
-                if (utimensat(AT_FDCWD, (parentdir / it->first).c_str(), newtimes, AT_SYMLINK_NOFOLLOW) == -1) {
+                if (utimensat(AT_FDCWD, (currentdir / it->first).c_str(), newtimes, AT_SYMLINK_NOFOLLOW) == -1) {
                     cerr << "Error while processing " << it->first << ": ";
                     perror("utimensat");
                 }

--- a/dracut/sync-etc-state.cpp
+++ b/dracut/sync-etc-state.cpp
@@ -198,6 +198,7 @@ bool copy_xattrs(filesystem::path ref, filesystem::path target) {
 int main(int argc, const char* argv[])
 {
     bool dry_run = false;
+    bool keep_syncpoint = false;
     int argpos = 1;
     filesystem::path syncpoint = "/etc/etc.syncpoint";
     filesystem::path currentdir = "/etc";
@@ -207,11 +208,14 @@ int main(int argc, const char* argv[])
         if (string(argv[1]) == "--dry-run" || string(argv[1]) == "-n") {
             dry_run = true;
             argpos++;
+        } else if (string(argv[1]) == "--keep-syncpoint") {
+            keep_syncpoint = true;
+            argpos++;
         }
     }
     if (argc - argpos != 3) {
         cerr << "Wrong number of arguments." << endl;
-        cerr << "Arguments: [--dry-run|-n] <parent etc> <current etc> <reference etc>" << endl;
+        cerr << "Arguments: [--dry-run|-n] [--keep-syncpoint] <parent etc> <current etc> <reference etc>" << endl;
         _exit(1);
     }
 
@@ -393,7 +397,9 @@ int main(int argc, const char* argv[])
             }
         }
 
-        filesystem::remove_all(syncpoint);
+        if (!keep_syncpoint) {
+            filesystem::remove_all(syncpoint);
+        }
     }
 
     return 0;

--- a/dracut/sync-etc-state.cpp
+++ b/dracut/sync-etc-state.cpp
@@ -227,7 +227,13 @@ int main(int argc, const char* argv[])
 
     // Check which files have been changed in new snapshot
     filesystem::current_path(syncpoint);
-    for (const filesystem::directory_entry& dir_entry : filesystem::recursive_directory_iterator(".")) {
+    auto it = filesystem::recursive_directory_iterator(".");
+    for (const filesystem::directory_entry& dir_entry : it) {
+        if (dir_entry.path().native() == "./etc.syncpoint") {
+            it.disable_recursion_pending();
+            continue;
+        }
+
         if (! filesystem::exists(filesystem::symlink_status(currentdir / dir_entry))) {
             cout << "Deleted in new snapshot: " << currentdir / dir_entry << endl;
             DIFFTOCURRENT.emplace(dir_entry, SYNC_ACTIONS::RECURSIVE_SKIP);
@@ -245,18 +251,29 @@ int main(int argc, const char* argv[])
         }
     }
     filesystem::current_path(currentdir);
-    for (const filesystem::directory_entry& dir_entry : filesystem::recursive_directory_iterator(".")) {
+    it = filesystem::recursive_directory_iterator(".");
+    for (const filesystem::directory_entry& dir_entry : it) {
+        if (dir_entry.path().native() == "./etc.syncpoint") {
+            it.disable_recursion_pending();
+            continue;
+        }
+
         if (! filesystem::exists(filesystem::symlink_status(syncpoint / dir_entry))) {
-            if (dir_entry.path().native().compare(0, 15, "./etc.syncpoint") != 0) {
-                cout << "Added in new snapshot: " << currentdir / dir_entry << endl;
-                DIFFTOCURRENT.emplace(dir_entry, SYNC_ACTIONS::SKIP);
-            }
+            cout << "Added in new snapshot: " << currentdir / dir_entry << endl;
+            DIFFTOCURRENT.emplace(dir_entry, SYNC_ACTIONS::SKIP);
         }
     }
 
     // Check which files have been changed in old snapshot
     filesystem::current_path(syncpoint);
-    for (const filesystem::directory_entry& dir_entry : filesystem::recursive_directory_iterator(".")) {
+    it = filesystem::recursive_directory_iterator(".");
+    for (const filesystem::directory_entry& dir_entry : it) {
+        // The syncpoint shouldn't have syncpoint inside, but for good measure let's just skip that too
+        if (dir_entry.path().native() == "./etc.syncpoint") {
+            it.disable_recursion_pending();
+            continue;
+        }
+
         if (! filesystem::exists(filesystem::symlink_status(parentdir / dir_entry))) {
             cout << "Deleted in old snapshot: " << parentdir / dir_entry << endl;
             if (DIFFTOCURRENT.count(dir_entry) == 0) {
@@ -286,7 +303,13 @@ int main(int argc, const char* argv[])
         }
     }
     filesystem::current_path(parentdir);
-    for (const filesystem::directory_entry& dir_entry : filesystem::recursive_directory_iterator(".")) {
+    it = filesystem::recursive_directory_iterator(".");
+    for (const filesystem::directory_entry& dir_entry : it) {
+        if (dir_entry.path().native() == "./etc.syncpoint") {
+            it.disable_recursion_pending();
+            continue;
+        }
+
         if (! filesystem::exists(filesystem::symlink_status(syncpoint / dir_entry))) {
             cout << "Added in old snapshot: " << parentdir / dir_entry << endl;
             DIFFTOCURRENT.emplace(dir_entry, SYNC_ACTIONS::COPY);

--- a/lib/Transaction.cpp
+++ b/lib/Transaction.cpp
@@ -521,7 +521,7 @@ void Transaction::finalize() {
                 tulog.info("Merging changes in /etc into the previous snapshot.");
                 targetRoot = pImpl->snapshotMgr->open(base)->getRoot();
             }
-            Util::exec("rsync --archive --inplace --xattrs --acls --exclude 'fstab' --delete --quiet '" + this->pImpl->bindDir.native() + "/etc/' " + targetRoot.native() + "/etc");
+            Util::exec("rsync --archive --inplace --xattrs --acls --exclude 'fstab' --exclude 'etc.syncpoint' --delete --quiet '" + this->pImpl->bindDir.native() + "/etc/' " + targetRoot.native() + "/etc");
         }
 
 	TransactionalUpdate::Plugins plugins_without_transaction{nullptr};

--- a/snapper/50-etc
+++ b/snapper/50-etc
@@ -20,8 +20,18 @@ create_reference_etc() {
     rmdir "/.snapshots/${snapshot}/snapshot/etc/etc.syncpoint"
   fi
   # Syncing is only necessary when the snapshot is based on the currently running system.
+  # "Current" means the snapshot number of the currently running /usr
+  current="$(findmnt --target /usr --raw --noheadings --output FSROOT | tail -n 1 | cut -d '/' -f 4)"
+
+  # If the parent snapshot was created from the running system, perform a sync now and use the current running /etc as syncpoint
+  if [ -e "/.snapshots/${parent}/snapshot/etc/etc.syncpoint/transactional-update.comparewith" ] \
+     && [ "$(cat "/.snapshots/${parent}/snapshot/etc/etc.syncpoint/transactional-update.comparewith")" = "${current}" ]; then
+    # Snapshot first, then sync to avoid racing with changes to /etc in between.
+    btrfs subvolume snapshot "/etc" "/.snapshots/${snapshot}/snapshot/etc/etc.syncpoint"
+    /usr/libexec/transactional-update-sync-etc-state --keep-syncpoint "/.snapshots/${snapshot}/snapshot/etc/etc.syncpoint" "/.snapshots/${snapshot}/snapshot/etc" "/.snapshots/${parent}/snapshot/etc/etc.syncpoint"
+    echo "${current}" > "/.snapshots/${snapshot}/snapshot/etc/etc.syncpoint/transactional-update.comparewith"
   # If it's the first descendant of the current system store a reference copy of the state before changes will be applied ...
-  if [ "/@/.snapshots/${parent}/snapshot" = "$(findmnt --target /usr --raw --noheadings --output FSROOT | tail -n 1 | cut -d '/' -f 1-5)" ]; then
+  elif [ "${parent}" = "${current}" ]; then
     btrfs subvolume snapshot "/.snapshots/${snapshot}/snapshot/etc" "/.snapshots/${snapshot}/snapshot/etc/etc.syncpoint"
     echo "${parent}" > "/.snapshots/${snapshot}/snapshot/etc/etc.syncpoint/transactional-update.comparewith"
   # ... or if it's a consecutive snapshot, copy the already existing syncpoint
@@ -37,6 +47,7 @@ create_snapshot_post() {
 
   # "Parent UUID" means which parent this snapshot was created from
   parentuuid="$(btrfs subvolume list -q / | grep -E " path @/.snapshots/${snapshot}/snapshot"$ | cut -f 9 -d ' ')"
+  # "Parent" is the number of the parent snapshot (as shown by snapper)
   parent="$(btrfs subvolume list -u / | grep " uuid ${parentuuid} " | cut -f 9- -d ' ' | cut -f 3 -d '/')"
   # "Parent ID" means the parent subvolume in the file system tree
   parentid="$(btrfs subvolume list / | grep -E " path @/.snapshots/${parent}/snapshot"$ | cut -f 2 -d ' ')"

--- a/tests/etc_changes.bats
+++ b/tests/etc_changes.bats
@@ -9,6 +9,8 @@ setup() {
 	mockdir_syncpoint="$(mktemp --directory /tmp/transactional-update.synctest.syncdir.XXXX)"
 
 	totest="../dracut/transactional-update-sync-etc-state"
+
+	umask 022
 }
 
 teardown() {

--- a/tests/etc_changes.bats
+++ b/tests/etc_changes.bats
@@ -211,10 +211,10 @@ debug() {
 		# Dir4 does not exist during snapshot creation
 		mkdir "${dir}/Dir5"
 		mkdir "${dir}/Dir5/Subdir"
-		touch mkdir "${dir}/Dir5/Subdir/FileInSubdir"
+		touch "${dir}/Dir5/Subdir/FileInSubdir"
 		mkdir "${dir}/Dir6"
 		mkdir "${dir}/Dir6/Subdir"
-		touch mkdir "${dir}/Dir6/Subdir/FileInSubdir"
+		touch "${dir}/Dir6/Subdir/FileInSubdir"
 		mkdir "${dir}/Dir7"
 		echo old > "${dir}/Dir7/ChangeInOld"
 		echo old > "${dir}/Dir7/ChangeInNew"

--- a/tests/etc_changes.bats
+++ b/tests/etc_changes.bats
@@ -349,6 +349,16 @@ debug() {
 	[ ! -e "${mockdir_new_etc}/File1" ]
 }
 
+@test "etc.syncpoint is skipped" {
+	mkdir -p "${mockdir_old_etc}/etc.syncpoint"
+	echo bla > "${mockdir_old_etc}/etc.syncpoint/file"
+
+	$totest "${mockdir_old_etc}" "${mockdir_new_etc}" "${mockdir_syncpoint}"
+
+	[ ! -e "${mockdir_new_etc}/etc.syncpoint/file" ]
+	[ ! -e "${mockdir_new_etc}/etc.syncpoint" ]
+}
+
 #cd /etc
 #
 ## Step 1: Prepare environment


### PR DESCRIPTION
Get changes from /etc into the new snapshot.

With this PR, the following workflow (as used by openQA) works again:

1. `transactional-update run echo hi`
2. Edit `/etc/default/grub`
3. `transactional-update -c grub.cfg`

Draft because not fully tested yet and it's also not fully clear which behavior is better :shrug:

~~I'm also not fully sure what to use as syncpoint here, this is unfortunately rather complex.~~