### PR TITLE
sbin/transactional-update.in: Fix stdio when returning from selfupdate

### DIFF
--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -836,7 +836,7 @@ else # Set exit handler to clean up artifacts of the self-update
         rm -rf "${TA_UPDATE_TMPFILE}"
         unset TA_UPDATE_TMPFILE
         unset LD_LIBRARY_PATH
-        exec transactional-update --no-selfupdate "${ORIG_ARGS[@]}"
+        exec transactional-update --no-selfupdate "${ORIG_ARGS[@]}" 1>&${origstdout} 2>&${origstderr}
     elif "${TA_UPDATE_TMPFILE}"/usr/sbin/tukit --version >/dev/null; then
         # tukit is executable - use new version
         export PATH="${TA_UPDATE_TMPFILE}/usr/sbin:${PATH}"
@@ -849,7 +849,7 @@ else # Set exit handler to clean up artifacts of the self-update
         rm -rf "${TA_UPDATE_TMPFILE}"
         unset TA_UPDATE_TMPFILE
         unset LD_LIBRARY_PATH
-        exec transactional-update --no-selfupdate "${ORIG_ARGS[@]}"
+        exec transactional-update --no-selfupdate "${ORIG_ARGS[@]}" 1>&${origstdout} 2>&${origstderr}
     fi
 fi
 


### PR DESCRIPTION
If the updated transactional-update script figures out that it does not run, it starts the original one again. Make sure it gets the original file descriptors for stdio again.

~~Draft because need to test this first.~~ Works as expected.