### PR TITLE
tukit signalize errors from plugins

### DIFF
--- a/lib/Plugins.cpp
+++ b/lib/Plugins.cpp
@@ -65,11 +65,14 @@ void Plugins::run(string stage, string args) {
 
         try {
             output = Util::exec(cmd);
-	    if (!output.empty())
-                tulog.info("Output of plugin ", p, ": ", output);
+            if (!output.empty())
+                tulog.info("Output of plugin ", p, ":\n", output, "---");
         } catch (const ExecutionException &e) {
-            // An error in the plugin should not discard the transaction
-            tulog.error("ERROR: Plugin ", p, " failed with ", e.what());
+            if (!e.output.empty()) {
+                tulog.error("ERROR: ", e.what());
+                tulog.error("Output of plugin ", p, ":\n", e.output, "---");
+            }
+            throw(e.returncode%255);
         }
     }
 }

--- a/lib/Plugins.hpp
+++ b/lib/Plugins.hpp
@@ -15,13 +15,14 @@ namespace TransactionalUpdate {
 
 class Plugins {
 public:
-    Plugins(TransactionalUpdate::Transaction* transaction);
+    Plugins(TransactionalUpdate::Transaction* transaction, bool ignore_error);
     virtual ~Plugins();
     void run(std::string stage, std::string args);
     void run(std::string stage, char* argv[]);
 protected:
     TransactionalUpdate::Transaction* transaction;
     std::vector<std::filesystem::path> plugins;
+    bool ignore_error;
 };
 
 } // namespace TransactionalUpdate

--- a/lib/Reboot.cpp
+++ b/lib/Reboot.cpp
@@ -104,7 +104,7 @@ Reboot::Reboot(std::string method) {
 }
 
 void Reboot::reboot() {
-    TransactionalUpdate::Plugins plugins{nullptr};
+    TransactionalUpdate::Plugins plugins{nullptr, false};
     plugins.run("reboot-pre", nullptr);
     Util::exec(command);
 }

--- a/lib/Transaction.hpp
+++ b/lib/Transaction.hpp
@@ -50,6 +50,13 @@ public:
     void init(std::string base, std::optional<std::string> description = std::nullopt);
 
     /**
+     * @brief Set flag to keep snapshots if plugins or command return error code
+     * @param keep true or false
+     *
+     */
+    void setKeepIfError(bool keep);
+
+    /**
      * @brief Set flag to discard snapshots if no changes are detected
      * @param discard true or false
      *

--- a/lib/Util.cpp
+++ b/lib/Util.cpp
@@ -9,6 +9,7 @@
 #include "Util.hpp"
 #include "Exceptions.hpp"
 #include <algorithm>
+#include <sys/wait.h>
 
 namespace TransactionalUpdate {
 
@@ -37,7 +38,10 @@ string Util::exec(const string cmd) {
 
     tulog.debug("◸", result, "◿");
     if (rc != EXIT_SUCCESS) {
-        throw ExecutionException{"`" + cmd + "` returned with error code " + to_string(rc) + ".", rc, result};
+        if (WIFEXITED(rc))
+            throw ExecutionException{"`" + cmd + "` returned with error code " + to_string(WEXITSTATUS(rc)) + ".", rc, result};
+        if (WIFSIGNALED(rc))
+           throw ExecutionException{"`" + cmd + "` exited via signal " + to_string(WTERMSIG(rc)) + ".", rc, result};
     }
 
     return result;

--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -13,6 +13,7 @@ VERBOSITY=2
 ZYPPER_ARG=""
 ZYPPER_ARG_EXTRA=()
 ZYPPER_NONINTERACTIVE="-y --auto-agree-with-product-licenses"
+KEEP_SNAPSHOT=0
 REWRITE_BOOTLOADER=0
 REWRITE_GRUB_CFG=0
 REWRITE_GRUB_CFG_NO_REBOOT=0
@@ -165,6 +166,7 @@ usage() {
     echo "--continue [<number>], -c  Use latest or given snapshot as base"
     echo "--no-selfupdate            Skip checking for newer version"
     echo "--drop-if-no-change, -d    Drop the snapshot if there is no change"
+    echo "--keep, -k                 Keep the snapshot even if there is an error"
     echo "--quiet                    Don't print warnings and infos to stdout"
     echo "--help, -h                 Display this help and exit"
     echo "--version                  Display version and exit"
@@ -271,7 +273,7 @@ quit() {
         echo -n "${REBOOT_LEVEL_PREV}" > "${NEEDS_RESTARTING_FILE}"
     fi
 
-    if [ -n "${SNAPSHOT_ID}" ] ; then
+    if [ -n "${SNAPSHOT_ID}" ] && [ "$KEEP_SNAPSHOT" -eq 0 ]; then
         log_error "Removing snapshot #${SNAPSHOT_ID}..."
         tukit ${TUKIT_OPTS} abort "${SNAPSHOT_ID}" |& tee -a ${LOGFILE}
     fi
@@ -665,6 +667,11 @@ parse_args() {
                 ;;
             -d|--drop-if-no-change)
                 TUKIT_OPTS="${TUKIT_OPTS} --discard"
+                shift
+                ;;
+            -k|--keep)
+                TUKIT_OPTS="${TUKIT_OPTS} --keep"
+                KEEP_SNAPSHOT=1
                 shift
                 ;;
             --quiet)

--- a/tukit/tukit.cpp
+++ b/tukit/tukit.cpp
@@ -55,6 +55,7 @@ void TUKit::displayHelp() {
     cout << "Transaction Options:\n";
     cout << "--continue[=<ID>], -c[<ID>]  Use latest or given snapshot as base\n";
     cout << "--description=<description>  Use custom snapshot description for \"open\"\n";
+    cout << "--keep, -k                   Keep snapshot even if there is an error\n";
     cout << "--discard, -d                Discard snapshot if no files were changed in root\n";
     cout << "\n";
     cout << "Snapshot Commands:\n";
@@ -81,6 +82,7 @@ int TUKit::parseOptions(int argc, char *argv[]) {
     static const struct option longopts[] = {
         { "continue", optional_argument, nullptr, 'c' },
         { "description", required_argument, nullptr, 0 },
+        { "keep", no_argument, nullptr, 'k' },
         { "discard", no_argument, nullptr, 'd' },
         { "fields", required_argument, nullptr, 'f' },
         { "help", no_argument, nullptr, 'h' },
@@ -103,6 +105,9 @@ int TUKit::parseOptions(int argc, char *argv[]) {
                 baseSnapshot = optarg;
             else
                 baseSnapshot = "default";
+            break;
+        case 'k':
+            keepSnapshot = true;
             break;
         case 'd':
             discardSnapshot = true;
@@ -138,6 +143,9 @@ int TUKit::processCommand(char *argv[]) {
     string arg = argv[0];
     if (arg == "execute") {
         TransactionalUpdate::Transaction transaction{};
+        if (keepSnapshot) {
+            transaction.setKeepIfError(true);
+        }
         if (discardSnapshot) {
             transaction.setDiscardIfUnchanged(true);
         }
@@ -152,6 +160,9 @@ int TUKit::processCommand(char *argv[]) {
     }
     else if (arg == "open") {
         TransactionalUpdate::Transaction transaction{};
+        if (keepSnapshot) {
+            transaction.setKeepIfError(true);
+        }
         if (discardSnapshot) {
             transaction.setDiscardIfUnchanged(true);
         }
@@ -166,6 +177,9 @@ int TUKit::processCommand(char *argv[]) {
             throw invalid_argument{"Missing argument for 'call'"};
         }
         TransactionalUpdate::Transaction transaction{};
+        if (keepSnapshot) {
+            transaction.setKeepIfError(true);
+        }
         transaction.resume(argv[1]);
         int status = transaction.execute(&argv[2]); // All remaining arguments
         transaction.keep();
@@ -177,6 +191,9 @@ int TUKit::processCommand(char *argv[]) {
             throw invalid_argument{"Missing argument for 'callext'"};
         }
         TransactionalUpdate::Transaction transaction{};
+        if (keepSnapshot) {
+            transaction.setKeepIfError(true);
+        }
         transaction.resume(argv[1]);
         int status = transaction.callExt(&argv[2]); // All remaining arguments
         transaction.keep();
@@ -188,6 +205,9 @@ int TUKit::processCommand(char *argv[]) {
             throw invalid_argument{"Missing argument for 'close'"};
         }
         TransactionalUpdate::Transaction transaction{};
+        if (keepSnapshot) {
+            transaction.setKeepIfError(true);
+        }
         transaction.resume(argv[1]);
         transaction.finalize();
         return 0;
@@ -198,6 +218,9 @@ int TUKit::processCommand(char *argv[]) {
             throw invalid_argument{"Missing argument for 'abort'"};
         }
         TransactionalUpdate::Transaction transaction{};
+        if (keepSnapshot) {
+            transaction.setKeepIfError(true);
+        }
         transaction.resume(argv[1]);
         return 0;
     }

--- a/tukit/tukit.hpp
+++ b/tukit/tukit.hpp
@@ -21,6 +21,7 @@ public:
     int processCommand(char *argv[]);
 private:
     std::string baseSnapshot = "active";
+    bool keepSnapshot = false;
     bool discardSnapshot = false;
     std::string fields;
     std::optional<std::string> description = std::nullopt;


### PR DESCRIPTION
Plugins can now abort transactions if they return with non zero.  Also
logs the output in separate lines in cases of success or failure of
execution.