### PR TITLE
Only mount /var/lib/selinux if it exists (jsc#PED-12492)

### DIFF
--- a/lib/Transaction.cpp
+++ b/lib/Transaction.cpp
@@ -135,8 +135,10 @@ void Transaction::impl::snapMount() {
             // up in the root file system, but will always be shadowed by the real /var mount. Due to that they
             // also won't be relabelled at any time. During updates this may cause problems if packages try to
             // access those leftover directories with wrong permissions, so they have to be relabelled manually...
-            BindMount selinuxVar("/var/lib/selinux", 0, true);
-            selinuxVar.mount(bindDir);
+            if (fs::is_directory("/var/lib/selinux")) {
+                BindMount selinuxVar("/var/lib/selinux", 0, true);
+                selinuxVar.mount(bindDir);
+            }
             BindMount selinuxEtc("/etc/selinux", 0, true);
             selinuxEtc.mount(bindDir);
 


### PR DESCRIPTION
Otherwise t-u will fail in every transaction if /var/lib/selinux does not exist. (which we want to make SELinux ready for image-based systems)

Repo with patched t-u for testing: https://build.opensuse.org/package/show/home:cahu:branches:Base:System/transactional-update

Before:
- Add repo for the /var/lib/selinux fix:  `https://build.opensuse.org/package/show/home:djz88:branches:security:SELinux/selinux-policy`
- Install: `transactional-update pkg in --allow-vendor-change selinux-policy libsemanage-conf libsemanage2`
- Then run: `rm /var/lib/selinux` then run `transactional-update dup` 
- fails with:
```
$ transactional-update dup
Checking for newer version.
transactional-update 5.0.7 started
Options: dup
Separate /var detected.
2025-09-24 11:47:49 tukit 5.0.7 started
2025-09-24 11:47:49 Options: -c3 open 
2025-09-24 11:47:50 Using snapshot 3 as base for new snapshot 4.
2025-09-24 11:47:50 Discarding snapshot 4.
ERROR: Mounting '/var/lib/selinux': special device /var/lib/selinux does not exist
transactional-update finished
```

After installing t-u from test repo: does not fail


I did not test anything else